### PR TITLE
feat: add table block support via @lexical/table

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,4 +1,3 @@
-
 {
   "name": "@hawkdoc/web",
   "version": "0.1.0",
@@ -20,6 +19,7 @@
     "@lexical/react": "^0.17.1",
     "@lexical/rich-text": "^0.17.1",
     "@lexical/selection": "^0.17.1",
+    "@lexical/table": "^0.17.1",
     "@lexical/utils": "^0.17.1",
     "@react-pdf/renderer": "^3.4.4",
     "@tanstack/react-virtual": "^3.8.1",
@@ -29,15 +29,15 @@
     "react-dom": "^18.3.1"
   },
   "optionalDependencies": {
-    "@rollup/rollup-linux-x64-gnu": "*",
-    "@rollup/rollup-darwin-x64": "*",
     "@rollup/rollup-darwin-arm64": "*",
+    "@rollup/rollup-darwin-x64": "*",
+    "@rollup/rollup-linux-x64-gnu": "*",
     "@rollup/rollup-win32-x64-msvc": "*"
   },
   "devDependencies": {
+    "@eslint/js": "^9.8.0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
-    "@eslint/js": "^9.8.0",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
     "@vitejs/plugin-react": "^4.3.1",

--- a/apps/web/src/components/Editor.tsx
+++ b/apps/web/src/components/Editor.tsx
@@ -26,6 +26,7 @@ import { CodeNode, CodeHighlightNode } from '@lexical/code';
 import { LinkNode, AutoLinkNode } from '@lexical/link';
 import { HorizontalRuleNode } from '@lexical/react/LexicalHorizontalRuleNode';
 import { LexicalErrorBoundary } from '@lexical/react/LexicalErrorBoundary';
+import { TableNode, TableRowNode, TableCellNode } from '@lexical/table';
 
 import { EditorToolbar } from './EditorToolbar';
 import { SlashCommandMenu } from './SlashCommandMenu';
@@ -34,6 +35,7 @@ import { CodeBlockPlugin } from './CodeBlockPlugin';
 import { DocumentPDF } from './DocumentPDF';
 import { TemplateVariableNode, $createTemplateVariableNode } from '../nodes/TemplateVariableNode';
 import { ImageNode } from '../nodes/ImageNode';
+import { TablePlugin } from '../plugins/TablePlugin';
 import { useAutoSave, loadAutoSave } from '../hooks/useAutoSave';
 
 const TEMPLATE_VAR_REGEX = /\{\{([a-zA-Z_][a-zA-Z0-9_]*)\}\}/;
@@ -209,6 +211,11 @@ export function Editor({ title, onTitleChange }: EditorProps) {
       quote: 'editor-quote',
       code: 'editor-code',
       link: 'editor-link',
+      table: 'editor-table',
+      tableCell: 'editor-table-cell',
+      tableCellHeader: 'editor-table-cell-header',
+      tableRow: 'editor-table-row',
+      tableSelection: 'editor-table-selection',
     },
     nodes: [
       HeadingNode,
@@ -222,6 +229,9 @@ export function Editor({ title, onTitleChange }: EditorProps) {
       HorizontalRuleNode,
       TemplateVariableNode,
       ImageNode,
+      TableNode,
+      TableRowNode,
+      TableCellNode,
     ],
     onError: (error: Error) => {
       console.error('Lexical error:', error);
@@ -283,6 +293,7 @@ export function Editor({ title, onTitleChange }: EditorProps) {
                 <EditorRefPlugin onEditor={setEditorInstance} />
                 <RestorePlugin initialContent={initialContent} />
                 <CodeBlockPlugin />
+                <TablePlugin />
               </div>
 
               {slashMenu && editorInstance && (

--- a/apps/web/src/components/Editor.tsx
+++ b/apps/web/src/components/Editor.tsx
@@ -35,7 +35,7 @@ import { CodeBlockPlugin } from './CodeBlockPlugin';
 import { DocumentPDF } from './DocumentPDF';
 import { TemplateVariableNode, $createTemplateVariableNode } from '../nodes/TemplateVariableNode';
 import { ImageNode } from '../nodes/ImageNode';
-import { TablePlugin } from '../plugins/TablePlugin';
+import { TablePlugin } from './TablePlugin';
 import { useAutoSave, loadAutoSave } from '../hooks/useAutoSave';
 
 const TEMPLATE_VAR_REGEX = /\{\{([a-zA-Z_][a-zA-Z0-9_]*)\}\}/;

--- a/apps/web/src/components/SlashCommandMenu.tsx
+++ b/apps/web/src/components/SlashCommandMenu.tsx
@@ -24,7 +24,7 @@ import { $insertNodeToNearestRoot } from '@lexical/utils';
 import { $createCodeNode } from '@lexical/code';
 import { $createHorizontalRuleNode } from '@lexical/react/LexicalHorizontalRuleNode';
 import { $createTemplateVariableNode } from '../nodes/TemplateVariableNode';
-import { INSERT_TABLE_COMMAND } from '../plugins/TablePlugin';
+import { INSERT_TABLE_COMMAND } from '@lexical/table';
 
 interface SlashCommand {
   id: string;

--- a/apps/web/src/components/SlashCommandMenu.tsx
+++ b/apps/web/src/components/SlashCommandMenu.tsx
@@ -24,6 +24,7 @@ import { $insertNodeToNearestRoot } from '@lexical/utils';
 import { $createCodeNode } from '@lexical/code';
 import { $createHorizontalRuleNode } from '@lexical/react/LexicalHorizontalRuleNode';
 import { $createTemplateVariableNode } from '../nodes/TemplateVariableNode';
+import { INSERT_TABLE_COMMAND } from '../plugins/TablePlugin';
 
 interface SlashCommand {
   id: string;
@@ -157,6 +158,19 @@ const COMMANDS: SlashCommand[] = [
         const code = $createCodeNode();
         parent.replace(code);
         code.select();
+      });
+    },
+  },
+  {
+    id: 'table',
+    label: 'Table',
+    description: 'Insert a table',
+    icon: '⊞',
+    execute: (editor) => {
+      editor.dispatchCommand(INSERT_TABLE_COMMAND, {
+        rows: '3',
+        columns: '3',
+        includeHeaders: { rows: true, columns: false },
       });
     },
   },

--- a/apps/web/src/components/TablePlugin.tsx
+++ b/apps/web/src/components/TablePlugin.tsx
@@ -9,12 +9,9 @@ import {
   $deleteTableColumn__EXPERIMENTAL,
   $deleteTableRow__EXPERIMENTAL,
   $isTableRowNode,
-  INSERT_TABLE_COMMAND,
 } from '@lexical/table';
 import { $getSelection, $isRangeSelection } from 'lexical';
 import { Plus, Trash2 } from 'lucide-react';
-
-export { INSERT_TABLE_COMMAND };
 
 function TableActionMenuPlugin(): JSX.Element | null {
   const [editor] = useLexicalComposerContext();

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -93,6 +93,27 @@
            mx-0.5 align-middle;
   }
 
+  /* ─── Table ─── */
+  .editor-table {
+    @apply w-full border-collapse my-4;
+  }
+
+  .editor-table-row {
+  }
+
+  .editor-table-cell {
+    @apply border border-notion-border px-3 py-2 text-sm align-top min-w-[80px];
+  }
+
+  .editor-table-cell-header {
+    @apply border border-notion-border px-3 py-2 text-sm align-top min-w-[80px]
+           bg-notion-hover font-semibold;
+  }
+
+  .editor-table-selection {
+    @apply bg-blue-50;
+  }
+
   /* ─── Slash command menu ─── */
   .slash-menu {
     @apply absolute z-50 bg-white rounded-xl shadow-2xl border border-notion-border

--- a/apps/web/src/plugins/TablePlugin.tsx
+++ b/apps/web/src/plugins/TablePlugin.tsx
@@ -1,0 +1,160 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { TablePlugin as LexicalTablePlugin } from '@lexical/react/LexicalTablePlugin';
+import {
+  $findCellNode,
+  $findTableNode,
+  $insertTableColumn__EXPERIMENTAL,
+  $insertTableRow__EXPERIMENTAL,
+  $deleteTableColumn__EXPERIMENTAL,
+  $deleteTableRow__EXPERIMENTAL,
+  $isTableRowNode,
+  INSERT_TABLE_COMMAND,
+} from '@lexical/table';
+import { $getSelection, $isRangeSelection } from 'lexical';
+import { Plus, Trash2 } from 'lucide-react';
+
+export { INSERT_TABLE_COMMAND };
+
+function TableActionMenuPlugin(): JSX.Element | null {
+  const [editor] = useLexicalComposerContext();
+  const [showMenu, setShowMenu] = useState(false);
+  const [menuPos, setMenuPos] = useState({ top: 0, left: 0 });
+
+  useEffect(() => {
+    return editor.registerUpdateListener(({ editorState }) => {
+      editorState.read(() => {
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection)) {
+          setShowMenu(false);
+          return;
+        }
+        const cell = $findCellNode(selection.anchor.getNode());
+        if (!cell) {
+          setShowMenu(false);
+          return;
+        }
+        const domElement = editor.getElementByKey(cell.getKey());
+        if (!domElement) {
+          setShowMenu(false);
+          return;
+        }
+        const rect = domElement.getBoundingClientRect();
+        setMenuPos({ top: rect.top - 36, left: rect.right + 4 });
+        setShowMenu(true);
+      });
+    });
+  }, [editor]);
+
+  const addRow = useCallback(() => {
+    editor.update(() => {
+      $insertTableRow__EXPERIMENTAL();
+    });
+  }, [editor]);
+
+  const addColumn = useCallback(() => {
+    editor.update(() => {
+      $insertTableColumn__EXPERIMENTAL();
+    });
+  }, [editor]);
+
+  const deleteRow = useCallback(() => {
+    editor.update(() => {
+      const selection = $getSelection();
+      if (!$isRangeSelection(selection)) return;
+      const cell = $findCellNode(selection.anchor.getNode());
+      const table = cell ? $findTableNode(cell) : null;
+      if (!table) return;
+      const rows = table.getChildren();
+      if (rows.length <= 1) {
+        table.remove();
+        return;
+      }
+      $deleteTableRow__EXPERIMENTAL();
+    });
+  }, [editor]);
+
+  const deleteColumn = useCallback(() => {
+    editor.update(() => {
+      const selection = $getSelection();
+      if (!$isRangeSelection(selection)) return;
+      const cell = $findCellNode(selection.anchor.getNode());
+      const table = cell ? $findTableNode(cell) : null;
+      if (!table) return;
+      const firstRow = table.getFirstChild();
+      const colCount = firstRow && $isTableRowNode(firstRow) ? firstRow.getChildren().length : 0;
+      if (colCount <= 1) {
+        table.remove();
+        return;
+      }
+      $deleteTableColumn__EXPERIMENTAL();
+    });
+  }, [editor]);
+
+  if (!showMenu) return null;
+
+  return (
+    <div
+      className="fixed z-50 flex items-center gap-0.5 bg-white rounded-lg shadow-lg border border-notion-border px-1 py-0.5"
+      style={{ top: menuPos.top, left: menuPos.left }}
+      onMouseDown={(e) => e.preventDefault()}
+    >
+      <ActionBtn title="Add row below" onClick={addRow}>
+        <Plus size={12} />
+        <span className="text-[10px]">Row</span>
+      </ActionBtn>
+      <ActionBtn title="Add column right" onClick={addColumn}>
+        <Plus size={12} />
+        <span className="text-[10px]">Col</span>
+      </ActionBtn>
+      <div className="w-px h-4 bg-notion-border mx-0.5" />
+      <ActionBtn title="Delete row" onClick={deleteRow} danger>
+        <Trash2 size={12} />
+        <span className="text-[10px]">Row</span>
+      </ActionBtn>
+      <ActionBtn title="Delete column" onClick={deleteColumn} danger>
+        <Trash2 size={12} />
+        <span className="text-[10px]">Col</span>
+      </ActionBtn>
+    </div>
+  );
+}
+
+function ActionBtn({
+  children,
+  title,
+  onClick,
+  danger,
+}: {
+  children: React.ReactNode;
+  title: string;
+  onClick: () => void;
+  danger?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      title={title}
+      className={`flex items-center gap-0.5 px-1.5 py-1 rounded text-xs transition-colors
+        ${danger
+          ? 'text-red-400 hover:text-red-600 hover:bg-red-50'
+          : 'text-notion-muted hover:text-notion-text hover:bg-notion-hover'
+        }`}
+      onMouseDown={(e) => {
+        e.preventDefault();
+        onClick();
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function TablePlugin(): JSX.Element {
+  return (
+    <>
+      <LexicalTablePlugin />
+      <TableActionMenuPlugin />
+    </>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
         "@lexical/react": "^0.17.1",
         "@lexical/rich-text": "^0.17.1",
         "@lexical/selection": "^0.17.1",
+        "@lexical/table": "^0.17.1",
         "@lexical/utils": "^0.17.1",
         "@react-pdf/renderer": "^3.4.4",
         "@tanstack/react-virtual": "^3.8.1",
@@ -803,6 +804,8 @@
     },
     "node_modules/@lexical/table": {
       "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.17.1.tgz",
+      "integrity": "sha512-2fUYPmxhyuMQX3MRvSsNaxbgvwGNJpHaKx1Ldc+PT2MvDZ6ALZkfsxbi0do54Q3i7dOon8/avRp4TuVaCnqvoA==",
       "license": "MIT",
       "dependencies": {
         "@lexical/utils": "0.17.1",
@@ -5939,7 +5942,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }


### PR DESCRIPTION
## Description

Add table blocks to the editor using Lexical's official `@lexical/table` package. Tables are insertable via the slash command menu (`/table`) and start as 3x3 with a styled header row.

**What's included:**
- Tab/Shift+Tab and arrow key navigation between cells
- Rich text formatting inside cells (bold, italic, etc.)
- Floating action menu to add/remove rows and columns
- Notion-inspired table styling with header row highlight
- Full serialization support (auto-save and restore work)

## Why this matters

Tables are the single biggest missing block type. The [CONTRIBUTING.md](https://github.com/hawk-doc/hawkdoc/blob/main/CONTRIBUTING.md) lists "new block types for the editor" as a welcome contribution, and every competing open-source document editor ships table support:

| Editor | Tables |
|--------|--------|
| [BlockNote](https://github.com/TypeCellOS/BlockNote) (8k+ stars) | Yes |
| [Docmost](https://docmost.com/) (7k+ stars) | Yes (with merge/resize) |
| [Plate](https://github.com/udecode/plate) | Yes (with merge/resize) |
| **HawkDoc** | **No - until this PR** |

This PR uses Lexical's official `@lexical/table` package, which is maintained by Meta and versioned in lockstep with the Lexical core (both at ^0.17.1). No third-party dependencies added.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Docs / chore

## How to test

1. `npm install` then `npm run dev --workspace=apps/web`
2. Open the editor and type `/table`
3. Select "Table" from the slash command menu
4. A 3x3 table appears with a styled header row
5. Click into cells and type - rich text formatting (bold, italic) works
6. Press Tab to move to the next cell, Shift+Tab to go back
7. Use arrow keys to navigate between cells
8. Click a cell, then use the floating action menu (appears to the right) to add/remove rows and columns
9. Refresh the page - the table persists via auto-save

## Screenshots

N/A - no design mockup. The table follows HawkDoc's existing Notion-inspired styling with `border-notion-border` borders, `bg-notion-hover` header row, and consistent padding.

## Checklist
- [x] Tests pass
- [x] No TypeScript errors (`npm run typecheck`)
- [x] No lint warnings (`npm run lint`)
- [ ] Docs updated if needed
- [x] Targets the `dev` branch (not `main`)

---

This contribution was developed with AI assistance (Claude Code).