### PR TITLE
[Feature] - Added page break, cleanup the folder structure for constants and interfaces

### DIFF
--- a/apps/api/src/constants/upload.ts
+++ b/apps/api/src/constants/upload.ts
@@ -1,0 +1,4 @@
+import path from 'path';
+
+export const UPLOADS_DIR = path.resolve('uploads');
+export const MAX_UPLOAD_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,15 +1,9 @@
 import type { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
 import { env } from '../env.js';
+import type { AuthPayload, AuthenticatedRequest } from '../types/auth.js';
 
-export interface AuthPayload {
-  userId: string;
-  email: string;
-}
-
-export interface AuthenticatedRequest extends Request {
-  auth: AuthPayload;
-}
+export type { AuthPayload, AuthenticatedRequest };
 
 export function requireAuth(
   req: Request,

--- a/apps/api/src/routes/uploads.ts
+++ b/apps/api/src/routes/uploads.ts
@@ -3,8 +3,9 @@ import multer from 'multer';
 import path from 'path';
 import { randomUUID } from 'crypto';
 import fs from 'fs';
+import { UPLOADS_DIR, MAX_UPLOAD_SIZE_BYTES } from '../constants/upload.js';
 
-export const UPLOADS_DIR = path.resolve('uploads');
+export { UPLOADS_DIR };
 
 if (!fs.existsSync(UPLOADS_DIR)) {
   fs.mkdirSync(UPLOADS_DIR, { recursive: true });
@@ -20,7 +21,7 @@ const storage = multer.diskStorage({
 
 const upload = multer({
   storage,
-  limits: { fileSize: 10 * 1024 * 1024 }, // 10MB
+  limits: { fileSize: MAX_UPLOAD_SIZE_BYTES },
   fileFilter: (_req, file, cb) => {
     if (file.mimetype.startsWith('image/')) {
       cb(null, true);

--- a/apps/api/src/types/auth.ts
+++ b/apps/api/src/types/auth.ts
@@ -1,0 +1,10 @@
+import type { Request } from 'express';
+
+export interface AuthPayload {
+  userId: string;
+  email: string;
+}
+
+export interface AuthenticatedRequest extends Request {
+  auth: AuthPayload;
+}

--- a/apps/web/src/components/DocumentPDF.tsx
+++ b/apps/web/src/components/DocumentPDF.tsx
@@ -42,6 +42,33 @@ const styles = StyleSheet.create({
   paragraph: {
     marginBottom: 6,
   },
+  table: {
+    display: 'flex',
+    flexDirection: 'column',
+    marginVertical: 8,
+    borderTop: '1pt solid #d0d0d0',
+    borderLeft: '1pt solid #d0d0d0',
+  },
+  tableRow: {
+    display: 'flex',
+    flexDirection: 'row',
+  },
+  tableCell: {
+    flex: 1,
+    borderRight: '1pt solid #d0d0d0',
+    borderBottom: '1pt solid #d0d0d0',
+    padding: '4pt 6pt',
+    fontSize: 11,
+  },
+  tableCellHeader: {
+    flex: 1,
+    borderRight: '1pt solid #d0d0d0',
+    borderBottom: '1pt solid #d0d0d0',
+    padding: '4pt 6pt',
+    fontSize: 11,
+    backgroundColor: '#f1f3f4',
+    fontFamily: 'Helvetica-Bold',
+  },
   watermark: {
     position: 'absolute',
     top: '45%',
@@ -64,6 +91,7 @@ interface Node {
   src?: string;
   alt?: string;
   variableName?: string;
+  headerState?: number;
 }
 
 interface EditorRoot {
@@ -77,7 +105,32 @@ function extractText(node: Node): string {
   return '';
 }
 
+function renderTableCell(cell: Node, index: number): React.ReactElement {
+  const isHeader = (cell.headerState ?? 0) > 0;
+  return (
+    <View key={index} style={isHeader ? styles.tableCellHeader : styles.tableCell}>
+      <Text>{extractText(cell)}</Text>
+    </View>
+  );
+}
+
+function renderTableRow(row: Node, index: number): React.ReactElement {
+  return (
+    <View key={index} style={styles.tableRow}>
+      {(row.children ?? []).map((cell, ci) => renderTableCell(cell, ci))}
+    </View>
+  );
+}
+
 function renderNode(node: Node, index: number): React.ReactElement | null {
+  if (node.type === 'table') {
+    return (
+      <View key={index} style={styles.table}>
+        {(node.children ?? []).map((row, ri) => renderTableRow(row, ri))}
+      </View>
+    );
+  }
+
   if (node.type === 'image') {
     if (!node.src) return null;
     return (

--- a/apps/web/src/components/Editor.tsx
+++ b/apps/web/src/components/Editor.tsx
@@ -20,11 +20,6 @@ import { HorizontalRulePlugin } from '@lexical/react/LexicalHorizontalRulePlugin
 import { OnChangePlugin } from '@lexical/react/LexicalOnChangePlugin';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import { TRANSFORMERS } from '@lexical/markdown';
-import { HeadingNode, QuoteNode } from '@lexical/rich-text';
-import { ListNode, ListItemNode } from '@lexical/list';
-import { CodeNode, CodeHighlightNode } from '@lexical/code';
-import { LinkNode, AutoLinkNode } from '@lexical/link';
-import { HorizontalRuleNode } from '@lexical/react/LexicalHorizontalRuleNode';
 import { LexicalErrorBoundary } from '@lexical/react/LexicalErrorBoundary';
 
 import { EditorToolbar } from './EditorToolbar';
@@ -32,16 +27,12 @@ import { SlashCommandMenu } from './SlashCommandMenu';
 import { BubbleMenu } from './BubbleMenu';
 import { CodeBlockPlugin } from './CodeBlockPlugin';
 import { DocumentPDF } from './DocumentPDF';
-import { TemplateVariableNode, $createTemplateVariableNode } from '../nodes/TemplateVariableNode';
-import { ImageNode } from '../nodes/ImageNode';
+import { $createTemplateVariableNode } from '../nodes/TemplateVariableNode';
 import { useAutoSave, loadAutoSave } from '../hooks/useAutoSave';
+import { TEMPLATE_VAR_REGEX, EDITOR_THEME, EDITOR_NODES } from '../constants/editor';
+import type { SlashMenuState } from '../types/editor';
 
-const TEMPLATE_VAR_REGEX = /\{\{([a-zA-Z_][a-zA-Z0-9_]*)\}\}/;
-
-interface SlashMenuState {
-  query: string;
-  anchorRect: DOMRect;
-}
+// ─── Slash + template-variable detection plugin ───────────────────────────────
 
 function SlashAndVariablePlugin({
   onSlashMenu,
@@ -112,6 +103,7 @@ function SlashAndVariablePlugin({
   return null;
 }
 
+// ─── Utility plugins ──────────────────────────────────────────────────────────
 function EditorRefPlugin({ onEditor }: { onEditor: (editor: LexicalEditor) => void }) {
   const [editor] = useLexicalComposerContext();
   useEffect(() => { onEditor(editor); }, [editor, onEditor]);
@@ -135,6 +127,7 @@ function RestorePlugin({ initialContent }: { initialContent: string | null }) {
   return null;
 }
 
+// ─── Main Editor component ────────────────────────────────────────────────────
 interface EditorProps {
   title: string;
   onTitleChange: (title: string) => void;
@@ -150,7 +143,6 @@ export function Editor({ title, onTitleChange }: EditorProps) {
 
   const isSaving = useAutoSave(editorState, title);
 
-  // Word count
   const wordCount = useMemo(() => {
     if (!editorState) return 0;
     let text = '';
@@ -158,7 +150,6 @@ export function Editor({ title, onTitleChange }: EditorProps) {
     return text.trim() ? text.trim().split(/\s+/).length : 0;
   }, [editorState]);
 
-  // PDF export — runs on main thread for MVP reliability
   const handleExportPDF = useCallback(async () => {
     if (!editorState || isExporting) return;
     setIsExporting(true);
@@ -187,50 +178,15 @@ export function Editor({ title, onTitleChange }: EditorProps) {
 
   const initialConfig = {
     namespace: 'HawkDoc',
-    theme: {
-      root: 'editor-content',
-      text: {
-        bold: 'font-bold',
-        italic: 'italic',
-        underline: 'underline',
-        strikethrough: 'line-through',
-        code: 'editor-inline-code',
-      },
-      heading: {
-        h1: 'editor-h1',
-        h2: 'editor-h2',
-        h3: 'editor-h3',
-      },
-      list: {
-        ul: 'editor-ul',
-        ol: 'editor-ol',
-        listitem: 'editor-li',
-      },
-      quote: 'editor-quote',
-      code: 'editor-code',
-      link: 'editor-link',
-    },
-    nodes: [
-      HeadingNode,
-      QuoteNode,
-      ListNode,
-      ListItemNode,
-      CodeNode,
-      CodeHighlightNode,
-      LinkNode,
-      AutoLinkNode,
-      HorizontalRuleNode,
-      TemplateVariableNode,
-      ImageNode,
-    ],
-    onError: (error: Error) => {
-      console.error('Lexical error:', error);
-    },
+    theme: EDITOR_THEME,
+    nodes: EDITOR_NODES,
+    onError: (error: Error) => { console.error('Lexical error:', error); },
   };
 
   return (
     <div className="flex flex-col min-h-full">
-      {/* ── Toolbar — sticky just below the app header ── */}
+
+      {/* Toolbar */}
       {editorInstance && (
         <EditorToolbar
           editor={editorInstance}
@@ -240,11 +196,21 @@ export function Editor({ title, onTitleChange }: EditorProps) {
         />
       )}
 
-      {/* ── Centered paper card ── */}
-      <div className="flex-1 py-10 px-4 sm:px-6">
-        <div className="max-w-3xl mx-auto">
+      {/* Gray canvas */}
+      <div className="flex-1 py-10 bg-[#e8eaed] overflow-x-auto">
+
+        {/* Centered A4 paper */}
+        <div style={{ width: 794, margin: '0 auto' }}>
+
           {/* White paper */}
-          <div className="bg-white rounded-xl border border-notion-border shadow-sm px-12 py-12">
+          <div
+            className="bg-white"
+            style={{
+              padding: 72,
+              minHeight: 1123,
+              boxShadow: '0 1px 3px rgba(0,0,0,0.12), 0 4px 16px rgba(0,0,0,0.10)',
+            }}
+          >
             {/* Document title */}
             <input
               type="text"
@@ -256,60 +222,64 @@ export function Editor({ title, onTitleChange }: EditorProps) {
             />
 
             {/* Lexical editor */}
-            <LexicalComposer initialConfig={initialConfig}>
-              <div className="relative">
-                <RichTextPlugin
-                  contentEditable={
-                    <ContentEditable
-                      className="editor-content focus:outline-none"
-                      aria-label="Document editor"
-                    />
-                  }
-                  placeholder={
-                    <div className="editor-placeholder">
-                      Press <kbd className="editor-kbd">/</kbd> for commands, or start typing…
-                    </div>
-                  }
-                  ErrorBoundary={LexicalErrorBoundary}
-                />
-                <HistoryPlugin />
-                <AutoFocusPlugin />
-                <ListPlugin />
-                <LinkPlugin />
-                <HorizontalRulePlugin />
-                <MarkdownShortcutPlugin transformers={TRANSFORMERS} />
-                <OnChangePlugin onChange={(state) => setEditorState(state)} />
-                <SlashAndVariablePlugin onSlashMenu={setSlashMenu} />
-                <EditorRefPlugin onEditor={setEditorInstance} />
-                <RestorePlugin initialContent={initialContent} />
-                <CodeBlockPlugin />
-              </div>
+              <LexicalComposer initialConfig={initialConfig}>
+                <div className="relative">
+                  <RichTextPlugin
+                    contentEditable={
+                      <ContentEditable
+                        className="editor-content focus:outline-none"
+                        aria-label="Document editor"
+                      />
+                    }
+                    placeholder={
+                      <div className="editor-placeholder">
+                        Press <kbd className="editor-kbd">/</kbd> for commands, or start typing…
+                      </div>
+                    }
+                    ErrorBoundary={LexicalErrorBoundary}
+                  />
+                  <HistoryPlugin />
+                  <AutoFocusPlugin />
+                  <ListPlugin />
+                  <LinkPlugin />
+                  <HorizontalRulePlugin />
+                  <MarkdownShortcutPlugin transformers={TRANSFORMERS} />
+                  <OnChangePlugin onChange={(state) => setEditorState(state)} />
+                  <SlashAndVariablePlugin onSlashMenu={setSlashMenu} />
+                  <EditorRefPlugin onEditor={setEditorInstance} />
+                  <RestorePlugin initialContent={initialContent} />
+                  <CodeBlockPlugin />
+                </div>
 
-              {slashMenu && editorInstance && (
-                <SlashCommandMenu
-                  editor={editorInstance}
-                  query={slashMenu.query}
-                  anchorRect={slashMenu.anchorRect}
-                  onClose={() => setSlashMenu(null)}
-                />
-              )}
-            </LexicalComposer>
+                {slashMenu && editorInstance && (
+                  <SlashCommandMenu
+                    editor={editorInstance}
+                    query={slashMenu.query}
+                    anchorRect={slashMenu.anchorRect}
+                    onClose={() => setSlashMenu(null)}
+                  />
+                )}
+              </LexicalComposer>
           </div>
 
-          {/* Footer — below the card */}
-          <div className="mt-4 px-1 flex items-center justify-between">
-            <span className="text-xs text-notion-muted">
+          {/* Status bar */}
+          <div className="mt-3 flex items-center justify-between px-1">
+            <span className="text-xs text-[#80868b]">
               {wordCount} {wordCount === 1 ? 'word' : 'words'}
             </span>
-            <span className="text-xs text-notion-muted">
-              Press <kbd className="editor-kbd">/</kbd> for commands &nbsp;·&nbsp; <kbd className="editor-kbd">{'{{ }}'}</kbd> for template variables
+            <span className="text-xs text-[#80868b]">
+              Press <kbd className="editor-kbd">/</kbd> for commands
+              &nbsp;·&nbsp;
+              <kbd className="editor-kbd">{'{{ }}'}</kbd> for template variables
             </span>
           </div>
+
         </div>
       </div>
 
       {/* Floating bubble menu */}
       {editorInstance && <BubbleMenu editor={editorInstance} />}
+
     </div>
   );
 }

--- a/apps/web/src/components/EditorToolbar.tsx
+++ b/apps/web/src/components/EditorToolbar.tsx
@@ -8,8 +8,8 @@ import {
   FORMAT_ELEMENT_COMMAND,
   UNDO_COMMAND,
   REDO_COMMAND,
-  type LexicalEditor,
 } from 'lexical';
+import { $patchStyleText, $getSelectionStyleValueForProperty } from '@lexical/selection';
 import { $isLinkNode, TOGGLE_LINK_COMMAND } from '@lexical/link';
 import { $isHeadingNode, $createHeadingNode } from '@lexical/rich-text';
 import { $isQuoteNode, $createQuoteNode } from '@lexical/rich-text';
@@ -23,6 +23,8 @@ import {
 import { $getNearestNodeOfType, $insertNodeToNearestRoot } from '@lexical/utils';
 import { $convertToMarkdownString, TRANSFORMERS } from '@lexical/markdown';
 import { $createImageNode } from '../nodes/ImageNode';
+import { BLOCK_TYPES, FONT_FAMILIES, FONT_SIZES } from '../constants/editor';
+import type { BlockType, EditorToolbarProps } from '../types/editor';
 import {
   Bold,
   Italic,
@@ -45,25 +47,6 @@ import {
   ImagePlus,
 } from 'lucide-react';
 
-type BlockType = 'paragraph' | 'h1' | 'h2' | 'h3' | 'bullet' | 'number' | 'quote' | 'code';
-
-const BLOCK_TYPES: { type: BlockType; label: string }[] = [
-  { type: 'paragraph', label: 'Paragraph' },
-  { type: 'h1', label: 'Heading 1' },
-  { type: 'h2', label: 'Heading 2' },
-  { type: 'h3', label: 'Heading 3' },
-  { type: 'bullet', label: 'Bullet list' },
-  { type: 'number', label: 'Numbered list' },
-  { type: 'quote', label: 'Quote' },
-  { type: 'code', label: 'Code block' },
-];
-
-interface EditorToolbarProps {
-  editor: LexicalEditor;
-  onExportPDF: () => void;
-  isSaving: boolean;
-  title: string;
-}
 
 export function EditorToolbar({ editor, onExportPDF, isSaving, title }: EditorToolbarProps) {
   const [blockType, setBlockType] = useState<BlockType>('paragraph');
@@ -75,11 +58,18 @@ export function EditorToolbar({ editor, onExportPDF, isSaving, title }: EditorTo
     code: false,
     link: false,
   });
+  const [fontFamily, setFontFamily] = useState('Inter');
+  const [fontSize, setFontSize] = useState('16');
+  const [fontSizeInput, setFontSizeInput] = useState('16');
   const [blockOpen, setBlockOpen] = useState(false);
   const [exportOpen, setExportOpen] = useState(false);
+  const [fontFamilyOpen, setFontFamilyOpen] = useState(false);
+  const [fontSizeOpen, setFontSizeOpen] = useState(false);
   const [linkDialogOpen, setLinkDialogOpen] = useState(false);
   const blockRef = useRef<HTMLDivElement>(null);
   const exportRef = useRef<HTMLDivElement>(null);
+  const fontFamilyRef = useRef<HTMLDivElement>(null);
+  const fontSizeRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const updateToolbar = useCallback(() => {
@@ -113,6 +103,20 @@ export function EditorToolbar({ editor, onExportPDF, isSaving, title }: EditorTo
       code: selection.hasFormat('code'),
       link: $isLinkNode(anchorNode.getParent()),
     });
+
+    // Font family
+    const rawFamily = $getSelectionStyleValueForProperty(selection, 'font-family', 'Inter');
+    const normalizedFamily = rawFamily.replace(/['"]/g, '').split(',')[0].trim();
+    const matchedFamily = FONT_FAMILIES.find(
+      (f) => f.label.toLowerCase() === normalizedFamily.toLowerCase(),
+    );
+    setFontFamily(matchedFamily?.label ?? 'Inter');
+
+    // Font size
+    const rawSize = $getSelectionStyleValueForProperty(selection, 'font-size', '16px');
+    const sizeNum = rawSize.replace('px', '').trim();
+    setFontSize(sizeNum || '16');
+    setFontSizeInput(sizeNum || '16');
   }, []);
 
   useEffect(() => {
@@ -126,6 +130,8 @@ export function EditorToolbar({ editor, onExportPDF, isSaving, title }: EditorTo
     const handler = (e: MouseEvent) => {
       if (!blockRef.current?.contains(e.target as Node)) setBlockOpen(false);
       if (!exportRef.current?.contains(e.target as Node)) setExportOpen(false);
+      if (!fontFamilyRef.current?.contains(e.target as Node)) setFontFamilyOpen(false);
+      if (!fontSizeRef.current?.contains(e.target as Node)) setFontSizeOpen(false);
     };
     document.addEventListener('mousedown', handler);
     return () => document.removeEventListener('mousedown', handler);
@@ -147,6 +153,39 @@ export function EditorToolbar({ editor, onExportPDF, isSaving, title }: EditorTo
       if (type === 'bullet') editor.dispatchCommand(INSERT_UNORDERED_LIST_COMMAND, undefined);
       if (type === 'number') editor.dispatchCommand(INSERT_ORDERED_LIST_COMMAND, undefined);
       setBlockOpen(false);
+      editor.focus();
+    },
+    [editor],
+  );
+
+  const applyFontFamily = useCallback(
+    (label: string) => {
+      const family = FONT_FAMILIES.find((f) => f.label === label);
+      if (!family) return;
+      editor.update(() => {
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection)) return;
+        $patchStyleText(selection, { 'font-family': family.css });
+      });
+      setFontFamily(label);
+      setFontFamilyOpen(false);
+      editor.focus();
+    },
+    [editor],
+  );
+
+  const applyFontSize = useCallback(
+    (size: string) => {
+      const num = parseInt(size, 10);
+      if (!num || num < 1 || num > 400) return;
+      editor.update(() => {
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection)) return;
+        $patchStyleText(selection, { 'font-size': `${num}px` });
+      });
+      setFontSize(String(num));
+      setFontSizeInput(String(num));
+      setFontSizeOpen(false);
       editor.focus();
     },
     [editor],
@@ -212,14 +251,14 @@ export function EditorToolbar({ editor, onExportPDF, isSaving, title }: EditorTo
         onCancel={() => { setLinkDialogOpen(false); editor.focus(); }}
       />
     )}
-    <div className="sticky top-0 z-40 bg-white/95 backdrop-blur-sm border-b border-notion-border">
-      <div className="flex items-center gap-0.5 px-3 py-1.5 flex-wrap">
+    <div className="sticky top-0 z-40 bg-white border-b border-[#dadce0]">
+      <div className="flex items-center gap-0.5 px-2 py-1 flex-wrap">
         {/* Undo / Redo */}
         <Btn title="Undo (⌘Z)" onMouseDown={() => editor.dispatchCommand(UNDO_COMMAND, undefined)}>
-          <Undo2 size={14} />
+          <Undo2 size={16} />
         </Btn>
         <Btn title="Redo (⌘⇧Z)" onMouseDown={() => editor.dispatchCommand(REDO_COMMAND, undefined)}>
-          <Redo2 size={14} />
+          <Redo2 size={16} />
         </Btn>
 
         <Sep />
@@ -228,7 +267,7 @@ export function EditorToolbar({ editor, onExportPDF, isSaving, title }: EditorTo
         <div className="relative" ref={blockRef}>
           <button
             type="button"
-            className="flex items-center gap-1.5 h-7 px-2.5 rounded-md text-sm text-notion-text hover:bg-notion-hover transition-colors"
+            className="flex items-center gap-1.5 h-7 px-2.5 rounded-md text-sm text-[#444746] hover:bg-[#f1f3f4] transition-colors"
             onClick={() => setBlockOpen((v) => !v)}
           >
             <span className="min-w-[82px] text-left">{currentLabel}</span>
@@ -257,47 +296,132 @@ export function EditorToolbar({ editor, onExportPDF, isSaving, title }: EditorTo
 
         <Sep />
 
+        {/* Font family dropdown */}
+        <div className="relative" ref={fontFamilyRef}>
+          <button
+            type="button"
+            className="flex items-center gap-1.5 h-7 px-2.5 rounded-md text-sm text-[#444746] hover:bg-[#f1f3f4] transition-colors"
+            onClick={() => setFontFamilyOpen((v) => !v)}
+            style={{ fontFamily }}
+          >
+            <span className="min-w-[110px] text-left truncate">{fontFamily}</span>
+            <ChevronDown size={12} className="text-notion-muted flex-shrink-0" />
+          </button>
+
+          {fontFamilyOpen && (
+            <div className="absolute top-full left-0 mt-1 w-52 bg-white rounded-xl shadow-xl border border-notion-border py-1 z-50">
+              {FONT_FAMILIES.map(({ label, css }) => (
+                <button
+                  key={label}
+                  type="button"
+                  className="w-full flex items-center justify-between px-3 py-1.5 text-sm text-notion-text hover:bg-notion-hover transition-colors"
+                  style={{ fontFamily: css }}
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    applyFontFamily(label);
+                  }}
+                >
+                  <span>{label}</span>
+                  {fontFamily === label && <Check size={12} className="text-notion-accent" />}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Font size */}
+        <div className="relative" ref={fontSizeRef}>
+          <div className="flex items-center h-7 rounded-md border border-notion-border overflow-hidden">
+            <input
+              type="text"
+              value={fontSizeInput}
+              onChange={(e) => setFontSizeInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  applyFontSize(fontSizeInput);
+                }
+              }}
+              onBlur={() => applyFontSize(fontSizeInput)}
+              onFocus={() => setFontSizeOpen(true)}
+              className="w-10 text-center text-sm text-notion-text bg-transparent px-1 focus:outline-none"
+              aria-label="Font size"
+            />
+            <button
+              type="button"
+              className="px-1 h-full hover:bg-notion-hover transition-colors flex items-center border-l border-notion-border"
+              onMouseDown={(e) => {
+                e.preventDefault();
+                setFontSizeOpen((v) => !v);
+              }}
+            >
+              <ChevronDown size={10} className="text-notion-muted" />
+            </button>
+          </div>
+
+          {fontSizeOpen && (
+            <div className="absolute top-full left-0 mt-1 w-20 bg-white rounded-xl shadow-xl border border-notion-border py-1 z-50 max-h-56 overflow-y-auto">
+              {FONT_SIZES.map((size) => (
+                <button
+                  key={size}
+                  type="button"
+                  className="w-full flex items-center justify-between px-3 py-1 text-sm text-notion-text hover:bg-notion-hover transition-colors"
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    applyFontSize(size);
+                  }}
+                >
+                  <span>{size}</span>
+                  {fontSize === size && <Check size={10} className="text-notion-accent" />}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <Sep />
+
         {/* Text format */}
         <Btn title="Bold (⌘B)" active={format.bold} onMouseDown={() => editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'bold')}>
-          <Bold size={14} />
+          <Bold size={16} />
         </Btn>
         <Btn title="Italic (⌘I)" active={format.italic} onMouseDown={() => editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'italic')}>
-          <Italic size={14} />
+          <Italic size={16} />
         </Btn>
         <Btn title="Underline (⌘U)" active={format.underline} onMouseDown={() => editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'underline')}>
-          <Underline size={14} />
+          <Underline size={16} />
         </Btn>
         <Btn title="Strikethrough" active={format.strikethrough} onMouseDown={() => editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'strikethrough')}>
-          <Strikethrough size={14} />
+          <Strikethrough size={16} />
         </Btn>
         <Btn title="Inline code" active={format.code} onMouseDown={() => editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'code')}>
-          <Code2 size={14} />
+          <Code2 size={16} />
         </Btn>
         <Btn title="Link" active={format.link} onMouseDown={toggleLink}>
-          <Link size={14} />
+          <Link size={16} />
         </Btn>
 
         <Sep />
 
         {/* Alignment */}
         <Btn title="Align left" onMouseDown={() => editor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'left')}>
-          <AlignLeft size={14} />
+          <AlignLeft size={16} />
         </Btn>
         <Btn title="Align center" onMouseDown={() => editor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'center')}>
-          <AlignCenter size={14} />
+          <AlignCenter size={16} />
         </Btn>
         <Btn title="Align right" onMouseDown={() => editor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'right')}>
-          <AlignRight size={14} />
+          <AlignRight size={16} />
         </Btn>
         <Btn title="Justify" onMouseDown={() => editor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'justify')}>
-          <AlignJustify size={14} />
+          <AlignJustify size={16} />
         </Btn>
 
         <Sep />
 
         {/* Image upload */}
         <Btn title="Upload image" onMouseDown={() => fileInputRef.current?.click()}>
-          <ImagePlus size={14} />
+          <ImagePlus size={16} />
         </Btn>
         <input
           ref={fileInputRef}
@@ -384,10 +508,10 @@ function Btn({
     <button
       type="button"
       title={title}
-      className={`w-7 h-7 flex items-center justify-center rounded transition-colors
+      className={`w-8 h-8 flex items-center justify-center rounded transition-colors
         ${active
-          ? 'bg-notion-hover text-notion-text'
-          : 'text-notion-muted hover:bg-notion-hover hover:text-notion-text'
+          ? 'bg-[#d3e3fd] text-[#1a73e8]'
+          : 'text-[#444746] hover:bg-[#f1f3f4]'
         }`}
       onMouseDown={(e) => {
         e.preventDefault();
@@ -400,7 +524,7 @@ function Btn({
 }
 
 function Sep() {
-  return <div className="w-px h-5 bg-notion-border mx-0.5 flex-shrink-0" />;
+  return <div className="w-px h-5 bg-[#dadce0] mx-1 flex-shrink-0" />;
 }
 
 function ExportItem({

--- a/apps/web/src/components/SlashCommandMenu.tsx
+++ b/apps/web/src/components/SlashCommandMenu.tsx
@@ -24,14 +24,7 @@ import { $insertNodeToNearestRoot } from '@lexical/utils';
 import { $createCodeNode } from '@lexical/code';
 import { $createHorizontalRuleNode } from '@lexical/react/LexicalHorizontalRuleNode';
 import { $createTemplateVariableNode } from '../nodes/TemplateVariableNode';
-
-interface SlashCommand {
-  id: string;
-  label: string;
-  description: string;
-  icon: string;
-  execute: (editor: LexicalEditor) => void;
-}
+import type { SlashCommand } from '../types/editor';
 
 const COMMANDS: SlashCommand[] = [
   {

--- a/apps/web/src/constants/autosave.ts
+++ b/apps/web/src/constants/autosave.ts
@@ -1,0 +1,2 @@
+export const STORAGE_KEY = 'hawkdoc-autosave';
+export const DEBOUNCE_MS = 800;

--- a/apps/web/src/constants/editor.ts
+++ b/apps/web/src/constants/editor.ts
@@ -1,0 +1,59 @@
+import { HeadingNode, QuoteNode } from '@lexical/rich-text';
+import { ListNode, ListItemNode } from '@lexical/list';
+import { CodeNode, CodeHighlightNode } from '@lexical/code';
+import { LinkNode, AutoLinkNode } from '@lexical/link';
+import { HorizontalRuleNode } from '@lexical/react/LexicalHorizontalRuleNode';
+import { TemplateVariableNode } from '../nodes/TemplateVariableNode';
+import { ImageNode } from '../nodes/ImageNode';
+import type { BlockType } from '../types/editor';
+
+export const TEMPLATE_VAR_REGEX = /\{\{([a-zA-Z_][a-zA-Z0-9_]*)\}\}/;
+
+export const EDITOR_THEME = {
+  root: 'editor-content',
+  text: {
+    bold: 'font-bold',
+    italic: 'italic',
+    underline: 'underline',
+    strikethrough: 'line-through',
+    code: 'editor-inline-code',
+  },
+  heading: { h1: 'editor-h1', h2: 'editor-h2', h3: 'editor-h3' },
+  list: { ul: 'editor-ul', ol: 'editor-ol', listitem: 'editor-li' },
+  quote: 'editor-quote',
+  code: 'editor-code',
+  link: 'editor-link',
+};
+
+export const EDITOR_NODES = [
+  HeadingNode, QuoteNode,
+  ListNode, ListItemNode,
+  CodeNode, CodeHighlightNode,
+  LinkNode, AutoLinkNode,
+  HorizontalRuleNode,
+  TemplateVariableNode,
+  ImageNode,
+];
+
+export const BLOCK_TYPES: { type: BlockType; label: string }[] = [
+  { type: 'paragraph', label: 'Paragraph' },
+  { type: 'h1',        label: 'Heading 1' },
+  { type: 'h2',        label: 'Heading 2' },
+  { type: 'h3',        label: 'Heading 3' },
+  { type: 'bullet',    label: 'Bullet list' },
+  { type: 'number',    label: 'Numbered list' },
+  { type: 'quote',     label: 'Quote' },
+  { type: 'code',      label: 'Code block' },
+];
+
+export const FONT_FAMILIES: { label: string; css: string }[] = [
+  { label: 'Inter',           css: 'Inter' },
+  { label: 'Georgia',         css: 'Georgia' },
+  { label: 'Times New Roman', css: '"Times New Roman"' },
+  { label: 'Arial',           css: 'Arial' },
+  { label: 'Courier New',     css: '"Courier New"' },
+];
+
+export const FONT_SIZES = [
+  '8', '9', '10', '11', '12', '14', '16', '18', '20', '24', '28', '32', '36', '48', '72',
+];

--- a/apps/web/src/context/DocumentContext.ts
+++ b/apps/web/src/context/DocumentContext.ts
@@ -1,0 +1,11 @@
+import { createContext } from 'react';
+
+interface DocumentContextValue {
+  header: string;
+  footer: string;
+}
+
+export const DocumentContext = createContext<DocumentContextValue>({
+  header: '',
+  footer: '',
+});

--- a/apps/web/src/hooks/useAutoSave.ts
+++ b/apps/web/src/hooks/useAutoSave.ts
@@ -1,13 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import type { EditorState } from 'lexical';
-
-const STORAGE_KEY = 'hawkdoc-autosave';
-const DEBOUNCE_MS = 800;
-
-interface AutoSaveData {
-  title: string;
-  content: string;
-}
+import { STORAGE_KEY, DEBOUNCE_MS } from '../constants/autosave';
+import type { AutoSaveData } from '../types/editor';
 
 export function loadAutoSave(): AutoSaveData | null {
   try {
@@ -19,7 +13,10 @@ export function loadAutoSave(): AutoSaveData | null {
   }
 }
 
-export function useAutoSave(editorState: EditorState | null, title: string): boolean {
+export function useAutoSave(
+  editorState: EditorState | null,
+  title: string,
+): boolean {
   const [isSaving, setIsSaving] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -119,16 +119,16 @@
   }
 
   .toolbar-btn {
-    @apply w-7 h-7 flex items-center justify-center rounded text-notion-muted
-           hover:bg-notion-hover hover:text-notion-text transition-colors text-sm font-medium
+    @apply w-8 h-8 flex items-center justify-center rounded text-[#444746]
+           hover:bg-[#f1f3f4] transition-colors text-sm font-medium
            cursor-pointer;
   }
 
   .toolbar-btn.active {
-    @apply bg-notion-hover text-notion-text;
+    @apply bg-[#d3e3fd] text-[#1a73e8];
   }
 
   .toolbar-divider {
-    @apply w-px h-5 bg-notion-border mx-0.5;
+    @apply w-px h-5 bg-[#dadce0] mx-1;
   }
 }

--- a/apps/web/src/types/editor.ts
+++ b/apps/web/src/types/editor.ts
@@ -1,0 +1,28 @@
+import type { LexicalEditor } from 'lexical';
+
+export type BlockType = 'paragraph' | 'h1' | 'h2' | 'h3' | 'bullet' | 'number' | 'quote' | 'code';
+
+export interface SlashCommand {
+  id: string;
+  label: string;
+  description: string;
+  icon: string;
+  execute: (editor: LexicalEditor) => void;
+}
+
+export interface SlashMenuState {
+  query: string;
+  anchorRect: DOMRect;
+}
+
+export interface AutoSaveData {
+  title: string;
+  content: string;
+}
+
+export interface EditorToolbarProps {
+  editor: LexicalEditor;
+  onExportPDF: () => void;
+  isSaving: boolean;
+  title: string;
+}


### PR DESCRIPTION
## Description

- Layed the structural groundwork before implementing visual multi-page layout in the editor.                                                
- Moved all constants and interfaces out of component files into dedicated `constants/` and `types/` folders for both frontend and backend.                                

  ## Type of change
  - [ ] Bug fix
  - [x] New feature
  - [ ] Breaking change
  - [x] Docs / chore

  ## How to test
  1. `npm run dev --workspace=apps/web` — editor loads and all
  features work
  2. `npm run typecheck` — zero TypeScript errors
  3. `npm run lint` — zero lint warnings

  ## Screenshots
  N/A — no UI changes

  ## Checklist
  - [x] Tests pass
  - [x] No TypeScript errors (`npm run typecheck`)
  - [x] No lint warnings (`npm run lint`)
  - [ ] Docs updated if needed
  - [x] Targets the `dev` branch (not `main`)