### PR TITLE
feat(editor): add color picker, focus mode, slash hints, copy markdow…

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,4 @@
-npm run typecheck --workspace=apps/web
-npm run typecheck --workspace=apps/api
+npx concurrently --kill-others-on-fail \
+  "npm run typecheck --workspace=apps/web" \
+  "npm run typecheck --workspace=apps/api"
 npx lint-staged

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "node --watch-path=src --env-file=.env --import tsx/esm src/index.ts",
+    "dev": "tsx watch --env-file=.env src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
     "typecheck": "tsc --noEmit"

--- a/apps/web/src/components/Editor.tsx
+++ b/apps/web/src/components/Editor.tsx
@@ -138,6 +138,7 @@ export function Editor({ title, onTitleChange }: EditorProps) {
   const [editorInstance, setEditorInstance] = useState<LexicalEditor | null>(null);
   const [editorState, setEditorState] = useState<EditorState | null>(null);
   const [slashMenu, setSlashMenu] = useState<SlashMenuState | null>(null);
+  const closeSlashMenu = useCallback(() => setSlashMenu(null), []);
   const [isExporting, setIsExporting] = useState(false);
   const [focusMode, setFocusMode] = useState(false);
 
@@ -278,7 +279,7 @@ export function Editor({ title, onTitleChange }: EditorProps) {
                     editor={editorInstance}
                     query={slashMenu.query}
                     anchorRect={slashMenu.anchorRect}
-                    onClose={() => setSlashMenu(null)}
+                    onClose={closeSlashMenu}
                   />
                 )}
               </LexicalComposer>

--- a/apps/web/src/components/Editor.tsx
+++ b/apps/web/src/components/Editor.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useMemo, useRef, useState, createElement } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, createElement, Fragment } from 'react';
+import { Minimize2 } from 'lucide-react';
 import { pdf } from '@react-pdf/renderer';
 import {
   $getRoot,
@@ -138,6 +139,14 @@ export function Editor({ title, onTitleChange }: EditorProps) {
   const [editorState, setEditorState] = useState<EditorState | null>(null);
   const [slashMenu, setSlashMenu] = useState<SlashMenuState | null>(null);
   const [isExporting, setIsExporting] = useState(false);
+  const [focusMode, setFocusMode] = useState(false);
+
+  useEffect(() => {
+    if (!focusMode) return;
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') setFocusMode(false); };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [focusMode]);
 
   const [initialContent] = useState<string | null>(() => loadAutoSave()?.content ?? null);
 
@@ -176,6 +185,17 @@ export function Editor({ title, onTitleChange }: EditorProps) {
     }
   }, [editorState, title, isExporting]);
 
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'p') {
+        e.preventDefault();
+        void handleExportPDF();
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [handleExportPDF]);
+
   const initialConfig = {
     namespace: 'HawkDoc',
     theme: EDITOR_THEME,
@@ -184,20 +204,22 @@ export function Editor({ title, onTitleChange }: EditorProps) {
   };
 
   return (
+    <Fragment>
     <div className="flex flex-col min-h-full">
 
-      {/* Toolbar */}
-      {editorInstance && (
+      {/* Toolbar — hidden in focus mode */}
+      {editorInstance && !focusMode && (
         <EditorToolbar
           editor={editorInstance}
           onExportPDF={handleExportPDF}
           isSaving={isSaving || isExporting}
           title={title}
+          onToggleFocusMode={() => setFocusMode(true)}
         />
       )}
 
       {/* Gray canvas */}
-      <div className="flex-1 py-10 bg-[#e8eaed] dark:bg-[#141414] overflow-x-auto">
+      <div className={`flex-1 py-10 overflow-x-auto transition-colors duration-300 ${focusMode ? 'bg-[#0d0d0d]' : 'bg-[#e8eaed] dark:bg-[#141414]'}`}>
 
         {/* Centered A4 paper */}
         <div className="w-[794px] mx-auto">
@@ -281,5 +303,18 @@ export function Editor({ title, onTitleChange }: EditorProps) {
       {editorInstance && <BubbleMenu editor={editorInstance} />}
 
     </div>
+
+    {/* Focus mode — floating exit button */}
+    {focusMode && (
+      <button
+        type="button"
+        onClick={() => setFocusMode(false)}
+        className="fixed top-4 right-4 z-50 flex items-center gap-1.5 px-3 py-1.5 bg-white/10 hover:bg-white/20 text-white/70 hover:text-white text-xs rounded-full backdrop-blur-sm transition-all"
+      >
+        <Minimize2 size={12} />
+        Exit focus · Esc
+      </button>
+    )}
+    </Fragment>
   );
 }

--- a/apps/web/src/components/EditorToolbar.tsx
+++ b/apps/web/src/components/EditorToolbar.tsx
@@ -45,10 +45,40 @@ import {
   Check,
   Globe,
   ImagePlus,
+  Type,
+  Highlighter,
+  Maximize2,
+  ClipboardCopy,
 } from 'lucide-react';
 
+const TEXT_COLORS = [
+  { label: 'Clear', value: '' },
+  { label: 'Black', value: '#1a1a1a' },
+  { label: 'Dark gray', value: '#444746' },
+  { label: 'Gray', value: '#80868b' },
+  { label: 'Red', value: '#d93025' },
+  { label: 'Orange', value: '#e8710a' },
+  { label: 'Yellow', value: '#f29900' },
+  { label: 'Green', value: '#1e8e3e' },
+  { label: 'Teal', value: '#007b83' },
+  { label: 'Blue', value: '#1a73e8' },
+  { label: 'Purple', value: '#9334e6' },
+  { label: 'Pink', value: '#e52592' },
+];
 
-export function EditorToolbar({ editor, onExportPDF, isSaving, title }: EditorToolbarProps) {
+const HIGHLIGHT_COLORS = [
+  { label: 'None', value: '' },
+  { label: 'Yellow', value: '#fef08a' },
+  { label: 'Green', value: '#bbf7d0' },
+  { label: 'Blue', value: '#bfdbfe' },
+  { label: 'Pink', value: '#fbcfe8' },
+  { label: 'Orange', value: '#fed7aa' },
+  { label: 'Purple', value: '#e9d5ff' },
+  { label: 'Red', value: '#fecaca' },
+];
+
+
+export function EditorToolbar({ editor, onExportPDF, isSaving, title, onToggleFocusMode }: EditorToolbarProps) {
   const [blockType, setBlockType] = useState<BlockType>('paragraph');
   const [format, setFormat] = useState({
     bold: false,
@@ -61,15 +91,21 @@ export function EditorToolbar({ editor, onExportPDF, isSaving, title }: EditorTo
   const [fontFamily, setFontFamily] = useState('Inter');
   const [fontSize, setFontSize] = useState('16');
   const [fontSizeInput, setFontSizeInput] = useState('16');
+  const [textColor, setTextColor] = useState('');
+  const [highlightColor, setHighlightColor] = useState('');
   const [blockOpen, setBlockOpen] = useState(false);
   const [exportOpen, setExportOpen] = useState(false);
   const [fontFamilyOpen, setFontFamilyOpen] = useState(false);
   const [fontSizeOpen, setFontSizeOpen] = useState(false);
+  const [colorOpen, setColorOpen] = useState(false);
+  const [highlightOpen, setHighlightOpen] = useState(false);
   const [linkDialogOpen, setLinkDialogOpen] = useState(false);
   const blockRef = useRef<HTMLDivElement>(null);
   const exportRef = useRef<HTMLDivElement>(null);
   const fontFamilyRef = useRef<HTMLDivElement>(null);
   const fontSizeRef = useRef<HTMLDivElement>(null);
+  const colorRef = useRef<HTMLDivElement>(null);
+  const highlightRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const updateToolbar = useCallback(() => {
@@ -117,6 +153,13 @@ export function EditorToolbar({ editor, onExportPDF, isSaving, title }: EditorTo
     const sizeNum = rawSize.replace('px', '').trim();
     setFontSize(sizeNum || '16');
     setFontSizeInput(sizeNum || '16');
+
+    // Text color
+    setTextColor($getSelectionStyleValueForProperty(selection, 'color', ''));
+
+    // Highlight color
+    const bg = $getSelectionStyleValueForProperty(selection, 'background-color', '');
+    setHighlightColor(bg === 'transparent' ? '' : bg);
   }, []);
 
   useEffect(() => {
@@ -132,6 +175,8 @@ export function EditorToolbar({ editor, onExportPDF, isSaving, title }: EditorTo
       if (!exportRef.current?.contains(e.target as Node)) setExportOpen(false);
       if (!fontFamilyRef.current?.contains(e.target as Node)) setFontFamilyOpen(false);
       if (!fontSizeRef.current?.contains(e.target as Node)) setFontSizeOpen(false);
+      if (!colorRef.current?.contains(e.target as Node)) setColorOpen(false);
+      if (!highlightRef.current?.contains(e.target as Node)) setHighlightOpen(false);
     };
     document.addEventListener('mousedown', handler);
     return () => document.removeEventListener('mousedown', handler);
@@ -199,6 +244,26 @@ export function EditorToolbar({ editor, onExportPDF, isSaving, title }: EditorTo
     }
   }, [editor, format.link]);
 
+  const applyTextColor = useCallback((color: string) => {
+    editor.update(() => {
+      const selection = $getSelection();
+      if (!$isRangeSelection(selection)) return;
+      $patchStyleText(selection, { color: color || '' });
+    });
+    setTextColor(color);
+    editor.focus();
+  }, [editor]);
+
+  const applyHighlightColor = useCallback((color: string) => {
+    editor.update(() => {
+      const selection = $getSelection();
+      if (!$isRangeSelection(selection)) return;
+      $patchStyleText(selection, { 'background-color': color || '' });
+    });
+    setHighlightColor(color);
+    editor.focus();
+  }, [editor]);
+
   const exportMarkdown = useCallback(() => {
     editor.getEditorState().read(() => {
       const md = $convertToMarkdownString(TRANSFORMERS);
@@ -214,6 +279,14 @@ export function EditorToolbar({ editor, onExportPDF, isSaving, title }: EditorTo
     download(`${title || 'document'}.html`, html, 'text/html');
     setExportOpen(false);
   }, [editor, title]);
+
+  const copyMarkdown = useCallback(() => {
+    editor.getEditorState().read(() => {
+      const md = $convertToMarkdownString(TRANSFORMERS);
+      void navigator.clipboard.writeText(md);
+    });
+    setExportOpen(false);
+  }, [editor]);
 
   const handleImageUpload = useCallback(
     async (file: File) => {
@@ -407,6 +480,49 @@ export function EditorToolbar({ editor, onExportPDF, isSaving, title }: EditorTo
 
         <Sep />
 
+        {/* Text color */}
+        <div className="relative" ref={colorRef}>
+          <button
+            type="button"
+            title="Text color"
+            className="w-8 h-8 flex flex-col items-center justify-center rounded transition-colors text-[#444746] dark:text-[#c4c7c5] hover:bg-[#f1f3f4] dark:hover:bg-[#2d2f31]"
+            onMouseDown={(e) => { e.preventDefault(); setColorOpen((v) => !v); setHighlightOpen(false); }}
+          >
+            <Type size={13} />
+            <div className="w-4 h-[3px] rounded-sm mt-0.5" style={{ backgroundColor: textColor || '#1a1a1a' }} />
+          </button>
+          {colorOpen && (
+            <ColorPalette
+              colors={TEXT_COLORS}
+              onSelect={(color) => { applyTextColor(color); setColorOpen(false); }}
+            />
+          )}
+        </div>
+
+        {/* Highlight color */}
+        <div className="relative" ref={highlightRef}>
+          <button
+            type="button"
+            title="Highlight color"
+            className="w-8 h-8 flex flex-col items-center justify-center rounded transition-colors text-[#444746] dark:text-[#c4c7c5] hover:bg-[#f1f3f4] dark:hover:bg-[#2d2f31]"
+            onMouseDown={(e) => { e.preventDefault(); setHighlightOpen((v) => !v); setColorOpen(false); }}
+          >
+            <Highlighter size={13} />
+            <div
+              className="w-4 h-[3px] rounded-sm mt-0.5 border border-[#dadce0] dark:border-[#3c4043]"
+              style={{ backgroundColor: highlightColor || 'transparent', borderWidth: highlightColor ? 0 : 1 }}
+            />
+          </button>
+          {highlightOpen && (
+            <ColorPalette
+              colors={HIGHLIGHT_COLORS}
+              onSelect={(color) => { applyHighlightColor(color); setHighlightOpen(false); }}
+            />
+          )}
+        </div>
+
+        <Sep />
+
         {/* Alignment */}
         <Btn title="Align left" onMouseDown={() => editor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'left')}>
           <AlignLeft size={16} />
@@ -438,6 +554,11 @@ export function EditorToolbar({ editor, onExportPDF, isSaving, title }: EditorTo
             e.target.value = '';
           }}
         />
+
+        {/* Focus mode */}
+        <Btn title="Focus mode" onMouseDown={onToggleFocusMode}>
+          <Maximize2 size={16} />
+        </Btn>
 
         {/* Spacer */}
         <div className="flex-1" />
@@ -482,6 +603,11 @@ export function EditorToolbar({ editor, onExportPDF, isSaving, title }: EditorTo
                 icon={<FileDown size={14} className="text-blue-500" />}
                 label="Export as Markdown"
                 onClick={exportMarkdown}
+              />
+              <ExportItem
+                icon={<ClipboardCopy size={14} className="text-blue-400" />}
+                label="Copy as Markdown"
+                onClick={copyMarkdown}
               />
               <ExportItem
                 icon={<Globe size={14} className="text-orange-500" />}
@@ -549,6 +675,33 @@ function ExportItem({
       {icon}
       {label}
     </button>
+  );
+}
+
+function ColorPalette({
+  colors,
+  onSelect,
+}: {
+  colors: { label: string; value: string }[];
+  onSelect: (color: string) => void;
+}) {
+  return (
+    <div className="absolute top-full left-0 mt-1 p-2 bg-white dark:bg-[#2d2f31] rounded-xl shadow-xl border border-notion-border dark:border-[#3c4043] z-50">
+      <div className="grid grid-cols-6 gap-1">
+        {colors.map(({ label, value }) => (
+          <button
+            key={label}
+            type="button"
+            title={label}
+            className="w-6 h-6 rounded-md border border-[#dadce0] dark:border-[#3c4043] hover:scale-110 transition-transform flex items-center justify-center"
+            style={{ backgroundColor: value || 'transparent' }}
+            onMouseDown={(e) => { e.preventDefault(); onSelect(value); }}
+          >
+            {!value && <span className="text-[9px] text-[#80868b]">✕</span>}
+          </button>
+        ))}
+      </div>
+    </div>
   );
 }
 

--- a/apps/web/src/components/EditorToolbar.tsx
+++ b/apps/web/src/components/EditorToolbar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { InputDialog } from './InputDialog';
 import {
   $getSelection,
@@ -264,13 +264,18 @@ export function EditorToolbar({ editor, onExportPDF, isSaving, title, onToggleFo
     editor.focus();
   }, [editor]);
 
-  const exportMarkdown = useCallback(() => {
+  const getMarkdownString = useCallback((): string => {
+    let md = '';
     editor.getEditorState().read(() => {
-      const md = $convertToMarkdownString(TRANSFORMERS);
-      download(`${title || 'document'}.md`, md, 'text/markdown');
+      md = $convertToMarkdownString(TRANSFORMERS);
     });
+    return md;
+  }, [editor]);
+
+  const exportMarkdown = useCallback(() => {
+    download(`${title || 'document'}.md`, getMarkdownString(), 'text/markdown');
     setExportOpen(false);
-  }, [editor, title]);
+  }, [getMarkdownString, title]);
 
   const exportHTML = useCallback(() => {
     const root = editor.getRootElement();
@@ -281,12 +286,11 @@ export function EditorToolbar({ editor, onExportPDF, isSaving, title, onToggleFo
   }, [editor, title]);
 
   const copyMarkdown = useCallback(() => {
-    editor.getEditorState().read(() => {
-      const md = $convertToMarkdownString(TRANSFORMERS);
-      void navigator.clipboard.writeText(md);
+    navigator.clipboard.writeText(getMarkdownString()).catch((err) => {
+      console.error('Copy as Markdown failed:', err);
     });
     setExportOpen(false);
-  }, [editor]);
+  }, [getMarkdownString]);
 
   const handleImageUpload = useCallback(
     async (file: File) => {
@@ -489,7 +493,10 @@ export function EditorToolbar({ editor, onExportPDF, isSaving, title, onToggleFo
             onMouseDown={(e) => { e.preventDefault(); setColorOpen((v) => !v); setHighlightOpen(false); }}
           >
             <Type size={13} />
-            <div className="w-4 h-[3px] rounded-sm mt-0.5" style={{ backgroundColor: textColor || '#1a1a1a' }} />
+            <div
+              className="w-4 h-[3px] rounded-sm mt-0.5 [background-color:var(--indicator-color)]"
+              style={{ '--indicator-color': textColor || '#1a1a1a' } as React.CSSProperties}
+            />
           </button>
           {colorOpen && (
             <ColorPalette
@@ -509,8 +516,8 @@ export function EditorToolbar({ editor, onExportPDF, isSaving, title, onToggleFo
           >
             <Highlighter size={13} />
             <div
-              className="w-4 h-[3px] rounded-sm mt-0.5 border border-[#dadce0] dark:border-[#3c4043]"
-              style={{ backgroundColor: highlightColor || 'transparent', borderWidth: highlightColor ? 0 : 1 }}
+              className={`w-4 h-[3px] rounded-sm mt-0.5 [background-color:var(--indicator-color)] ${highlightColor ? 'border-0' : 'border border-[#dadce0] dark:border-[#3c4043]'}`}
+              style={{ '--indicator-color': highlightColor || 'transparent' } as React.CSSProperties}
             />
           </button>
           {highlightOpen && (
@@ -693,9 +700,10 @@ function ColorPalette({
             key={label}
             type="button"
             title={label}
-            className="w-6 h-6 rounded-md border border-[#dadce0] dark:border-[#3c4043] hover:scale-110 transition-transform flex items-center justify-center"
-            style={{ backgroundColor: value || 'transparent' }}
-            onMouseDown={(e) => { e.preventDefault(); onSelect(value); }}
+            className="w-6 h-6 rounded-md border border-[#dadce0] dark:border-[#3c4043] hover:scale-110 transition-transform flex items-center justify-center [background-color:var(--swatch-color)]"
+            style={{ '--swatch-color': value || 'transparent' } as React.CSSProperties}
+            onMouseDown={(e) => { e.preventDefault(); }}
+            onClick={() => onSelect(value)}
           >
             {!value && <span className="text-[9px] text-[#80868b]">✕</span>}
           </button>

--- a/apps/web/src/components/SlashCommandMenu.tsx
+++ b/apps/web/src/components/SlashCommandMenu.tsx
@@ -34,6 +34,7 @@ const COMMANDS: SlashCommand[] = [
     label: 'Heading 1',
     description: 'Large section heading',
     icon: 'H1',
+    shortcut: '#',
     execute: (editor) => {
       editor.update(() => {
         const selection = $getSelection();
@@ -52,6 +53,7 @@ const COMMANDS: SlashCommand[] = [
     label: 'Heading 2',
     description: 'Medium section heading',
     icon: 'H2',
+    shortcut: '##',
     execute: (editor) => {
       editor.update(() => {
         const selection = $getSelection();
@@ -70,6 +72,7 @@ const COMMANDS: SlashCommand[] = [
     label: 'Heading 3',
     description: 'Small section heading',
     icon: 'H3',
+    shortcut: '###',
     execute: (editor) => {
       editor.update(() => {
         const selection = $getSelection();
@@ -106,6 +109,7 @@ const COMMANDS: SlashCommand[] = [
     label: 'Bullet List',
     description: 'Unordered list',
     icon: '•',
+    shortcut: '-',
     execute: (editor) => {
       editor.dispatchCommand(INSERT_UNORDERED_LIST_COMMAND, undefined);
     },
@@ -115,6 +119,7 @@ const COMMANDS: SlashCommand[] = [
     label: 'Numbered List',
     description: 'Ordered list',
     icon: '1.',
+    shortcut: '1.',
     execute: (editor) => {
       editor.dispatchCommand(INSERT_ORDERED_LIST_COMMAND, undefined);
     },
@@ -124,6 +129,7 @@ const COMMANDS: SlashCommand[] = [
     label: 'Quote',
     description: 'Block quotation',
     icon: '"',
+    shortcut: '>',
     execute: (editor) => {
       editor.update(() => {
         const selection = $getSelection();
@@ -142,6 +148,7 @@ const COMMANDS: SlashCommand[] = [
     label: 'Code Block',
     description: 'Monospace code block',
     icon: '</>',
+    shortcut: '```',
     execute: (editor) => {
       editor.update(() => {
         const selection = $getSelection();
@@ -173,6 +180,7 @@ const COMMANDS: SlashCommand[] = [
     label: 'Divider',
     description: 'Horizontal rule',
     icon: '—',
+    shortcut: '---',
     execute: (editor) => {
       editor.update(() => {
         const hr = $createHorizontalRuleNode();
@@ -200,6 +208,7 @@ const COMMANDS: SlashCommand[] = [
     label: 'Template Variable',
     description: 'Insert {{variable}} placeholder',
     icon: '{{}}',
+    shortcut: '{{}}',
     execute: () => { /* handled by SlashCommandMenu with InputDialog */ },
   },
 ];
@@ -354,10 +363,15 @@ export function SlashCommandMenu({
           }}
         >
           <span className="slash-menu-item-icon">{cmd.icon}</span>
-          <span>
+          <span className="flex-1 min-w-0">
             <span className="font-medium">{cmd.label}</span>
             <span className="block text-xs text-notion-muted">{cmd.description}</span>
           </span>
+          {cmd.shortcut && (
+            <kbd className="ml-3 flex-shrink-0 text-[10px] font-mono text-notion-muted bg-[#f1f3f4] px-1.5 py-0.5 rounded border border-[#dadce0]">
+              {cmd.shortcut}
+            </kbd>
+          )}
         </button>
       ))}
     </div>

--- a/apps/web/src/components/SlashCommandMenu.tsx
+++ b/apps/web/src/components/SlashCommandMenu.tsx
@@ -316,6 +316,12 @@ export function SlashCommandMenu({
     };
   }, [editor, filtered, selectedIndex, executeCommand, onClose]);
 
+  // Close on any scroll (capture catches non-bubbling scroll on overflow containers)
+  useEffect(() => {
+    document.addEventListener('scroll', onClose, { capture: true });
+    return () => document.removeEventListener('scroll', onClose, { capture: true });
+  }, [onClose]);
+
   // Reset selection when query changes
   useEffect(() => {
     setSelectedIndex(0);
@@ -342,14 +348,14 @@ export function SlashCommandMenu({
 
   if (filtered.length === 0) return null;
 
-  const top = anchorRect.bottom + window.scrollY + 4;
-  const left = Math.min(anchorRect.left + window.scrollX, window.innerWidth - 300);
+  const top = anchorRect.bottom + 4;
+  const left = Math.min(anchorRect.left, window.innerWidth - 300);
 
   return (
     <div
       ref={menuRef}
       className="slash-menu"
-      style={{ top, left, position: 'absolute' }}
+      style={{ top, left, position: 'fixed' }}
     >
       {filtered.map((cmd, index) => (
         <button
@@ -368,7 +374,7 @@ export function SlashCommandMenu({
             <span className="block text-xs text-notion-muted">{cmd.description}</span>
           </span>
           {cmd.shortcut && (
-            <kbd className="ml-3 flex-shrink-0 text-[10px] font-mono text-notion-muted bg-[#f1f3f4] px-1.5 py-0.5 rounded border border-[#dadce0]">
+            <kbd className="ml-3 flex-shrink-0 text-[10px] font-mono text-notion-muted dark:text-[#9aa0a6] bg-[#f1f3f4] dark:bg-[#3c4043] px-1.5 py-0.5 rounded border border-[#dadce0] dark:border-[#5f6368]">
               {cmd.shortcut}
             </kbd>
           )}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -7,6 +7,10 @@
     box-sizing: border-box;
   }
 
+  html {
+    @apply bg-notion-bg;
+  }
+
   body {
     @apply font-sans text-notion-text bg-notion-bg antialiased;
   }
@@ -134,7 +138,8 @@
   /* ─── Slash command menu ─── */
   .slash-menu {
     @apply absolute z-50 bg-white rounded-xl shadow-2xl border border-notion-border
-           w-72 py-1 overflow-hidden;
+           w-72 py-1 overflow-y-auto;
+    max-height: 320px;
   }
 
   .slash-menu-item {
@@ -169,6 +174,12 @@
   .toolbar-divider {
     @apply w-px h-5 bg-[#dadce0] mx-1;
   }
+}
+
+/* ─── Dark mode base — prevents white flash on overscroll / rubber-band ─── */
+html.dark,
+html.dark body {
+  background-color: #1a1a1a;
 }
 
 /* ─── Dark mode overrides for CSS-class-based editor styles ─── */

--- a/apps/web/src/types/editor.ts
+++ b/apps/web/src/types/editor.ts
@@ -7,6 +7,7 @@ export interface SlashCommand {
   label: string;
   description: string;
   icon: string;
+  shortcut?: string;
   execute: (editor: LexicalEditor) => void;
 }
 
@@ -25,4 +26,5 @@ export interface EditorToolbarProps {
   onExportPDF: () => void;
   isSaving: boolean;
   title: string;
+  onToggleFocusMode: () => void;
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
   ],
   "scripts": {
     "dev": "concurrently \"npm run dev --workspace=apps/web\" \"npm run dev --workspace=apps/api\"",
+    "dev:web": "npm run dev --workspace=apps/web",
+    "dev:api": "npm run dev --workspace=apps/api",
     "build": "npm run build --workspace=apps/web && npm run build --workspace=apps/api",
+    "start": "npm run start --workspace=apps/api",
     "lint": "npm run lint --workspaces --if-present",
     "typecheck": "npm run typecheck --workspaces --if-present",
     "prepare": "husky"


### PR DESCRIPTION


- Text color and highlight color pickers in toolbar with 12-color palette
- Focus mode: hides toolbar, darkens canvas, floating exit button + Esc to exit
- Slash command menu now shows markdown shortcut hints (e.g. ## → H2)
- Copy as Markdown option in export dropdown using clipboard API
- Cmd+P / Ctrl+P keyboard shortcut triggers PDF export

## Description
<!-- What changed and why -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Docs / chore

## How to test
<!-- Steps to verify this works -->

## Screenshots
<!-- If the UI changed, add before/after screenshots -->

## Checklist
- [ ] Tests pass
- [ ] No TypeScript errors (`npm run typecheck`)
- [ ] No lint warnings (`npm run lint`)
- [ ] Docs updated if needed
- [ ] Targets the `dev` branch (not `main`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a distraction-free focus mode with a prominent “Exit focus · Esc” control.
  * Expanded export options with “Copy as Markdown”, plus improved PDF shortcut handling (Ctrl/Cmd+P).
  * Added inline text color and highlight color formatting controls in the toolbar.
  * Show command shortcut hints in the slash menu.

* **Bug Fixes**
  * Improved slash menu behavior (closes on scroll/outside interactions) and updated sizing to prevent awkward overflow.
  * Reduced dark-mode white flash during overscroll.

* **Chores**
  * Improved development workflow scripts and pre-commit typecheck concurrency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->