### PR TITLE
[Feature] - Implement sidebar component and integrate document management feature

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,26 +1,25 @@
-import { useState } from 'react';
 import { Github, Sun, Moon } from 'lucide-react';
 import { Editor } from './components/Editor';
-import { loadAutoSave } from './hooks/useAutoSave';
+import { Sidebar } from './components/Sidebar';
+import { useDocumentStore } from './hooks/useDocumentStore';
 import { useTheme } from './hooks/useTheme';
 
 export default function App() {
-  const [title, setTitle] = useState<string>(() => loadAutoSave()?.title ?? 'Untitled');
   const { theme, toggle } = useTheme();
+  const { docs, activeId, create, rename, remove, activate, touch } = useDocumentStore();
+
+  const activeDoc = docs.find((d) => d.id === activeId);
+  const title = activeDoc?.title ?? 'Untitled';
 
   return (
     <div className="h-screen flex flex-col bg-notion-sidebar dark:bg-[#1a1a1a]">
       {/* ── Top header ── */}
       <header className="flex-shrink-0 h-[52px] bg-white dark:bg-[#202020] border-b border-notion-border dark:border-[#3c4043] flex items-center justify-between px-5 z-50">
-        {/* Brand */}
         <div className="flex items-center gap-2">
           <img src="/logo.png" alt="HawkDoc" className="w-6 h-6 object-contain" />
           <span className="font-semibold text-notion-text dark:text-[#e8eaed] text-[15px] tracking-tight">HawkDoc</span>
         </div>
-
-        {/* Right side actions */}
         <div className="flex items-center gap-1">
-          {/* Theme toggle */}
           <button
             onClick={toggle}
             title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
@@ -28,8 +27,6 @@ export default function App() {
           >
             {theme === 'dark' ? <Sun size={17} /> : <Moon size={17} />}
           </button>
-
-          {/* GitHub link */}
           <a
             href="https://github.com/hawk-doc/hawkdoc"
             target="_blank"
@@ -42,9 +39,25 @@ export default function App() {
         </div>
       </header>
 
-      {/* ── Scrollable editor area ── */}
-      <div className="flex-1 overflow-y-auto">
-        <Editor title={title} onTitleChange={setTitle} />
+      {/* ── Body: sidebar + editor ── */}
+      <div className="flex flex-1 overflow-hidden">
+        <Sidebar
+          docs={docs}
+          activeId={activeId}
+          onActivate={activate}
+          onCreate={create}
+          onRename={rename}
+          onDelete={remove}
+        />
+
+        <main className="flex-1 overflow-y-auto">
+          <Editor
+            key={activeId}
+            docId={activeId}
+            title={title}
+            onTitleChange={(t) => touch(activeId, t)}
+          />
+        </main>
       </div>
     </div>
   );

--- a/apps/web/src/components/DraggableBlockPlugin.tsx
+++ b/apps/web/src/components/DraggableBlockPlugin.tsx
@@ -1,0 +1,27 @@
+import { useRef } from 'react';
+import { GripVertical } from 'lucide-react';
+import { DraggableBlockPlugin_EXPERIMENTAL } from '@lexical/react/LexicalDraggableBlockPlugin';
+
+interface Props {
+  anchorElem: HTMLElement;
+}
+
+export function DraggableBlockPlugin({ anchorElem }: Props) {
+  const menuRef = useRef<HTMLDivElement>(null);
+  const targetLineRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <DraggableBlockPlugin_EXPERIMENTAL
+      anchorElem={anchorElem}
+      menuRef={menuRef}
+      targetLineRef={targetLineRef}
+      menuComponent={
+        <div ref={menuRef} className="drag-handle">
+          <GripVertical size={14} />
+        </div>
+      }
+      targetLineComponent={<div ref={targetLineRef} className="drag-target-line" />}
+      isOnMenu={(el) => !!menuRef.current?.contains(el)}
+    />
+  );
+}

--- a/apps/web/src/components/Editor.tsx
+++ b/apps/web/src/components/Editor.tsx
@@ -230,8 +230,8 @@ export function Editor({ docId, title, onTitleChange }: EditorProps) {
         />
       )}
 
-      {/* Gray canvas */}
-      <div className={`flex-1 py-10 overflow-x-auto transition-colors duration-300 ${focusMode ? 'bg-[#0d0d0d]' : 'bg-[#e8eaed] dark:bg-[#141414]'}`}>
+      {/* Gray canvas — fixed full-screen overlay in focus mode */}
+      <div className={`py-10 transition-colors duration-300 ${focusMode ? 'fixed inset-0 z-[100] overflow-y-auto bg-[#0d0d0d]' : 'flex-1 overflow-x-auto bg-[#e8eaed] dark:bg-[#141414]'}`}>
 
         {/* Centered A4 paper */}
         <div className="w-[794px] mx-auto">
@@ -324,7 +324,7 @@ export function Editor({ docId, title, onTitleChange }: EditorProps) {
       <button
         type="button"
         onClick={() => setFocusMode(false)}
-        className="fixed top-4 right-4 z-50 flex items-center gap-1.5 px-3 py-1.5 bg-white/10 hover:bg-white/20 text-white/70 hover:text-white text-xs rounded-full backdrop-blur-sm transition-all"
+        className="fixed top-4 right-4 z-[101] flex items-center gap-1.5 px-3 py-1.5 bg-white/10 hover:bg-white/20 text-white/70 hover:text-white text-xs rounded-full backdrop-blur-sm transition-all"
       >
         <Minimize2 size={12} />
         Exit focus · Esc

--- a/apps/web/src/components/Editor.tsx
+++ b/apps/web/src/components/Editor.tsx
@@ -30,6 +30,7 @@ import { DocumentPDF } from './DocumentPDF';
 import { $createTemplateVariableNode } from '../nodes/TemplateVariableNode';
 import { TablePlugin } from './TablePlugin';
 import { FindReplacePlugin } from './FindReplacePlugin';
+import { DraggableBlockPlugin } from './DraggableBlockPlugin';
 import { useAutoSave, loadDocContent } from '../hooks/useAutoSave';
 import { TEMPLATE_VAR_REGEX, EDITOR_THEME, EDITOR_NODES } from '../constants/editor';
 import type { SlashMenuState } from '../types/editor';
@@ -143,6 +144,8 @@ export function Editor({ docId, title, onTitleChange }: EditorProps) {
   const closeSlashMenu = useCallback(() => setSlashMenu(null), []);
   const [isExporting, setIsExporting] = useState(false);
   const [focusMode, setFocusMode] = useState(false);
+  const [anchorElem, setAnchorElem] = useState<HTMLElement | null>(null);
+  const onPaperRef = useCallback((el: HTMLDivElement | null) => { setAnchorElem(el); }, []);
 
   useEffect(() => {
     if (!focusMode) return;
@@ -234,7 +237,7 @@ export function Editor({ docId, title, onTitleChange }: EditorProps) {
         <div className="w-[794px] mx-auto">
 
           {/* White paper */}
-          <div className="bg-white dark:bg-[#1e1e1e] p-[72px] min-h-[1123px] shadow-[0_1px_3px_rgba(0,0,0,0.12),0_4px_16px_rgba(0,0,0,0.10)]">
+          <div ref={onPaperRef} className="relative bg-white dark:bg-[#1e1e1e] p-[72px] min-h-[1123px] shadow-[0_1px_3px_rgba(0,0,0,0.12),0_4px_16px_rgba(0,0,0,0.10)]">
             {/* Document title */}
             <textarea
               value={title}
@@ -281,6 +284,7 @@ export function Editor({ docId, title, onTitleChange }: EditorProps) {
                   <CodeBlockPlugin />
                   <TablePlugin />
                   <FindReplacePlugin />
+                  {anchorElem && <DraggableBlockPlugin anchorElem={anchorElem} />}
                 </div>
 
                 {slashMenu && editorInstance && (

--- a/apps/web/src/components/Editor.tsx
+++ b/apps/web/src/components/Editor.tsx
@@ -30,7 +30,7 @@ import { DocumentPDF } from './DocumentPDF';
 import { $createTemplateVariableNode } from '../nodes/TemplateVariableNode';
 import { TablePlugin } from './TablePlugin';
 import { FindReplacePlugin } from './FindReplacePlugin';
-import { useAutoSave, loadAutoSave } from '../hooks/useAutoSave';
+import { useAutoSave, loadDocContent } from '../hooks/useAutoSave';
 import { TEMPLATE_VAR_REGEX, EDITOR_THEME, EDITOR_NODES } from '../constants/editor';
 import type { SlashMenuState } from '../types/editor';
 
@@ -131,11 +131,12 @@ function RestorePlugin({ initialContent }: { initialContent: string | null }) {
 
 // ─── Main Editor component ────────────────────────────────────────────────────
 interface EditorProps {
+  docId: string;
   title: string;
   onTitleChange: (title: string) => void;
 }
 
-export function Editor({ title, onTitleChange }: EditorProps) {
+export function Editor({ docId, title, onTitleChange }: EditorProps) {
   const [editorInstance, setEditorInstance] = useState<LexicalEditor | null>(null);
   const [editorState, setEditorState] = useState<EditorState | null>(null);
   const [slashMenu, setSlashMenu] = useState<SlashMenuState | null>(null);
@@ -150,9 +151,9 @@ export function Editor({ title, onTitleChange }: EditorProps) {
     return () => document.removeEventListener('keydown', handler);
   }, [focusMode]);
 
-  const [initialContent] = useState<string | null>(() => loadAutoSave()?.content ?? null);
+  const [initialContent] = useState<string | null>(() => loadDocContent(docId)?.content ?? null);
 
-  const isSaving = useAutoSave(editorState, title);
+  const isSaving = useAutoSave(editorState, title, docId);
 
   const wordCount = useMemo(() => {
     if (!editorState) return 0;

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useRef, useState } from 'react';
+import { FilePlus, FileText, Trash2 } from 'lucide-react';
+import type { DocMeta } from '../types/editor';
+
+interface SidebarProps {
+  docs: DocMeta[];
+  activeId: string;
+  onActivate: (id: string) => void;
+  onCreate: () => void;
+  onRename: (id: string, title: string) => void;
+  onDelete: (id: string) => void;
+}
+
+export function Sidebar({ docs, activeId, onActivate, onCreate, onRename, onDelete }: SidebarProps) {
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editValue, setEditValue] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (editingId) inputRef.current?.select();
+  }, [editingId]);
+
+  const startEdit = (doc: DocMeta, e: React.MouseEvent) => {
+    e.stopPropagation();
+    setEditingId(doc.id);
+    setEditValue(doc.title || 'Untitled');
+  };
+
+  const commitEdit = () => {
+    if (!editingId) return;
+    onRename(editingId, editValue.trim() || 'Untitled');
+    setEditingId(null);
+  };
+
+  const sorted = [...docs].sort((a, b) => b.updatedAt - a.updatedAt);
+
+  return (
+    <aside className="sidebar">
+      <div className="sidebar-header">
+        <span className="text-xs font-semibold uppercase tracking-widest text-notion-muted dark:text-[#5f6368]">
+          Documents
+        </span>
+        <button type="button" title="New document" onClick={onCreate} className="sidebar-new-btn">
+          <FilePlus size={15} />
+        </button>
+      </div>
+
+      <nav className="flex-1 overflow-y-auto py-1 px-1">
+        {sorted.map((doc) => {
+          const isActive = doc.id === activeId;
+          const isEditing = doc.id === editingId;
+
+          return (
+            <div
+              key={doc.id}
+              className={`sidebar-item group ${isActive ? 'active' : ''}`}
+              onClick={() => !isEditing && onActivate(doc.id)}
+              onDoubleClick={(e) => startEdit(doc, e)}
+            >
+              <FileText size={13} className="flex-shrink-0 opacity-50" />
+
+              {isEditing ? (
+                <input
+                  ref={inputRef}
+                  value={editValue}
+                  onChange={(e) => setEditValue(e.target.value)}
+                  onBlur={commitEdit}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') commitEdit();
+                    if (e.key === 'Escape') setEditingId(null);
+                  }}
+                  onClick={(e) => e.stopPropagation()}
+                  className="sidebar-rename-input"
+                />
+              ) : (
+                <span className="flex-1 truncate">{doc.title || 'Untitled'}</span>
+              )}
+
+              {!isEditing && (
+                <button
+                  type="button"
+                  title="Delete"
+                  onClick={(e) => { e.stopPropagation(); onDelete(doc.id); }}
+                  className="sidebar-delete-btn"
+                >
+                  <Trash2 size={12} />
+                </button>
+              )}
+            </div>
+          );
+        })}
+      </nav>
+    </aside>
+  );
+}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { FilePlus, FileText, Trash2 } from 'lucide-react';
+import { FilePlus, FileText, Search, Trash2 } from 'lucide-react';
 import type { DocMeta } from '../types/editor';
 
 interface SidebarProps {
@@ -14,6 +14,7 @@ interface SidebarProps {
 export function Sidebar({ docs, activeId, onActivate, onCreate, onRename, onDelete }: SidebarProps) {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editValue, setEditValue] = useState('');
+  const [query, setQuery] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -33,62 +34,95 @@ export function Sidebar({ docs, activeId, onActivate, onCreate, onRename, onDele
   };
 
   const sorted = [...docs].sort((a, b) => b.updatedAt - a.updatedAt);
+  const q = query.trim().toLowerCase();
+  const filtered = q ? sorted.filter((d) => (d.title || 'Untitled').toLowerCase().includes(q)) : sorted;
+
+  const isEmptyState =
+    !q &&
+    docs.length === 1 &&
+    (!docs[0].title || docs[0].title === 'Untitled');
 
   return (
     <aside className="sidebar">
       <div className="sidebar-header">
         <span className="text-xs font-semibold uppercase tracking-widest text-notion-muted dark:text-[#5f6368]">
-          Documents
+          Documents&nbsp;·&nbsp;{docs.length}
         </span>
         <button type="button" title="New document" onClick={onCreate} className="sidebar-new-btn">
           <FilePlus size={15} />
         </button>
       </div>
 
+      <div className="sidebar-search-wrap">
+        <Search size={12} className="sidebar-search-icon" />
+        <input
+          type="text"
+          placeholder="Filter…"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          className="sidebar-search"
+        />
+      </div>
+
       <nav className="flex-1 overflow-y-auto py-1 px-1">
-        {sorted.map((doc) => {
-          const isActive = doc.id === activeId;
-          const isEditing = doc.id === editingId;
+        {isEmptyState ? (
+          <div className="sidebar-empty">
+            <FileText size={28} className="mb-2 opacity-30" />
+            <p className="text-xs font-medium mb-1">No documents yet</p>
+            <p className="text-[11px] opacity-60 text-center leading-snug">
+              Click <strong>+</strong> to create your first document
+            </p>
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="sidebar-empty">
+            <Search size={22} className="mb-2 opacity-30" />
+            <p className="text-xs font-medium">No matches</p>
+          </div>
+        ) : (
+          filtered.map((doc) => {
+            const isActive = doc.id === activeId;
+            const isEditing = doc.id === editingId;
 
-          return (
-            <div
-              key={doc.id}
-              className={`sidebar-item group ${isActive ? 'active' : ''}`}
-              onClick={() => !isEditing && onActivate(doc.id)}
-              onDoubleClick={(e) => startEdit(doc, e)}
-            >
-              <FileText size={13} className="flex-shrink-0 opacity-50" />
+            return (
+              <div
+                key={doc.id}
+                className={`sidebar-item group ${isActive ? 'active' : ''}`}
+                onClick={() => !isEditing && onActivate(doc.id)}
+                onDoubleClick={(e) => startEdit(doc, e)}
+              >
+                <FileText size={13} className="flex-shrink-0 opacity-50" />
 
-              {isEditing ? (
-                <input
-                  ref={inputRef}
-                  value={editValue}
-                  onChange={(e) => setEditValue(e.target.value)}
-                  onBlur={commitEdit}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') commitEdit();
-                    if (e.key === 'Escape') setEditingId(null);
-                  }}
-                  onClick={(e) => e.stopPropagation()}
-                  className="sidebar-rename-input"
-                />
-              ) : (
-                <span className="flex-1 truncate">{doc.title || 'Untitled'}</span>
-              )}
+                {isEditing ? (
+                  <input
+                    ref={inputRef}
+                    value={editValue}
+                    onChange={(e) => setEditValue(e.target.value)}
+                    onBlur={commitEdit}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') commitEdit();
+                      if (e.key === 'Escape') setEditingId(null);
+                    }}
+                    onClick={(e) => e.stopPropagation()}
+                    className="sidebar-rename-input"
+                  />
+                ) : (
+                  <span className="flex-1 truncate">{doc.title || 'Untitled'}</span>
+                )}
 
-              {!isEditing && (
-                <button
-                  type="button"
-                  title="Delete"
-                  onClick={(e) => { e.stopPropagation(); onDelete(doc.id); }}
-                  className="sidebar-delete-btn"
-                >
-                  <Trash2 size={12} />
-                </button>
-              )}
-            </div>
-          );
-        })}
+                {!isEditing && (
+                  <button
+                    type="button"
+                    title="Delete"
+                    onClick={(e) => { e.stopPropagation(); onDelete(doc.id); }}
+                    className="sidebar-delete-btn"
+                  >
+                    <Trash2 size={12} />
+                  </button>
+                )}
+              </div>
+            );
+          })
+        )}
       </nav>
     </aside>
   );

--- a/apps/web/src/constants/autosave.ts
+++ b/apps/web/src/constants/autosave.ts
@@ -1,2 +1,5 @@
 export const STORAGE_KEY = 'hawkdoc-autosave';
 export const DEBOUNCE_MS = 800;
+export const DOCS_LIST_KEY = 'hawkdoc-docs';
+export const DOC_KEY_PREFIX = 'hawkdoc-doc-';
+export const ACTIVE_DOC_KEY = 'hawkdoc-active-doc';

--- a/apps/web/src/hooks/useAutoSave.ts
+++ b/apps/web/src/hooks/useAutoSave.ts
@@ -1,16 +1,15 @@
 import { useEffect, useRef, useState } from 'react';
 import type { EditorState } from 'lexical';
-import { STORAGE_KEY, DEBOUNCE_MS } from '../constants/autosave';
+import { DOC_KEY_PREFIX, DEBOUNCE_MS } from '../constants/autosave';
 import type { AutoSaveData } from '../types/editor';
 
-export function loadAutoSave(): AutoSaveData | null {
+export function loadDocContent(docId: string): AutoSaveData | null {
   try {
-    const raw = localStorage.getItem(STORAGE_KEY);
+    const raw = localStorage.getItem(`${DOC_KEY_PREFIX}${docId}`);
     if (!raw) return null;
     const parsed: unknown = JSON.parse(raw);
     if (
       typeof parsed !== 'object' || parsed === null ||
-      typeof (parsed as Record<string, unknown>).title !== 'string' ||
       typeof (parsed as Record<string, unknown>).content !== 'string'
     ) return null;
     return parsed as AutoSaveData;
@@ -22,6 +21,7 @@ export function loadAutoSave(): AutoSaveData | null {
 export function useAutoSave(
   editorState: EditorState | null,
   title: string,
+  docId: string,
 ): boolean {
   const [isSaving, setIsSaving] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -33,22 +33,14 @@ export function useAutoSave(
     timerRef.current = setTimeout(() => {
       setIsSaving(true);
       try {
-        const data: AutoSaveData = {
-          title,
-          content: JSON.stringify(editorState.toJSON()),
-        };
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
-      } catch {
-        // ignore storage errors
-      }
-      // localStorage is synchronous — delay the flip so React renders "Saving…" first
+        const data: AutoSaveData = { title, content: JSON.stringify(editorState.toJSON()) };
+        localStorage.setItem(`${DOC_KEY_PREFIX}${docId}`, JSON.stringify(data));
+      } catch { /* ignore storage errors */ }
       setTimeout(() => setIsSaving(false), 600);
     }, DEBOUNCE_MS);
 
-    return () => {
-      if (timerRef.current) clearTimeout(timerRef.current);
-    };
-  }, [editorState, title]);
+    return () => { if (timerRef.current) clearTimeout(timerRef.current); };
+  }, [editorState, title, docId]);
 
   return isSaving;
 }

--- a/apps/web/src/hooks/useDocumentStore.ts
+++ b/apps/web/src/hooks/useDocumentStore.ts
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+import { DOCS_LIST_KEY, DOC_KEY_PREFIX, ACTIVE_DOC_KEY, STORAGE_KEY } from '../constants/autosave';
+import type { DocMeta } from '../types/editor';
+
+function genId(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+}
+
+function saveDocs(docs: DocMeta[]): void {
+  localStorage.setItem(DOCS_LIST_KEY, JSON.stringify(docs));
+}
+
+function initialDocs(): DocMeta[] {
+  try {
+    const raw = localStorage.getItem(DOCS_LIST_KEY);
+    if (raw) return JSON.parse(raw) as DocMeta[];
+  } catch { /* ignore */ }
+
+  // Migrate from old single-doc format
+  const id = genId();
+  const old = localStorage.getItem(STORAGE_KEY);
+  let title = 'Untitled';
+  try { if (old) title = (JSON.parse(old) as { title?: string }).title ?? 'Untitled'; } catch { /* ignore */ }
+  if (old) localStorage.setItem(`${DOC_KEY_PREFIX}${id}`, old);
+
+  const docs: DocMeta[] = [{ id, title, updatedAt: Date.now() }];
+  saveDocs(docs);
+  return docs;
+}
+
+function initialActiveId(docs: DocMeta[]): string {
+  const stored = localStorage.getItem(ACTIVE_DOC_KEY);
+  return stored && docs.some((d) => d.id === stored) ? stored : (docs[0]?.id ?? '');
+}
+
+export function useDocumentStore() {
+  const [docs, setDocs] = useState<DocMeta[]>(initialDocs);
+  const [activeId, setActiveId] = useState<string>(() => initialActiveId(initialDocs()));
+
+  const update = (next: DocMeta[]) => {
+    setDocs(next);
+    saveDocs(next);
+  };
+
+  const switchTo = (id: string) => {
+    setActiveId(id);
+    localStorage.setItem(ACTIVE_DOC_KEY, id);
+  };
+
+  const create = (): string => {
+    const id = genId();
+    const next = [{ id, title: 'Untitled', updatedAt: Date.now() }, ...docs];
+    update(next);
+    switchTo(id);
+    return id;
+  };
+
+  const rename = (id: string, title: string) => {
+    update(docs.map((d) => (d.id === id ? { ...d, title, updatedAt: Date.now() } : d)));
+  };
+
+  const remove = (id: string) => {
+    const next = docs.filter((d) => d.id !== id);
+    localStorage.removeItem(`${DOC_KEY_PREFIX}${id}`);
+    if (next.length === 0) {
+      const newId = genId();
+      const fresh: DocMeta[] = [{ id: newId, title: 'Untitled', updatedAt: Date.now() }];
+      update(fresh);
+      switchTo(newId);
+    } else {
+      update(next);
+      if (id === activeId) switchTo(next[0].id);
+    }
+  };
+
+  const touch = (id: string, title: string) => {
+    update(docs.map((d) => (d.id === id ? { ...d, title, updatedAt: Date.now() } : d)));
+  };
+
+  return { docs, activeId, create, rename, remove, activate: switchTo, touch };
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -226,6 +226,28 @@
            transition-all;
   }
 
+  .sidebar-search-wrap {
+    @apply relative flex items-center mx-3 my-2 flex-shrink-0;
+  }
+
+  .sidebar-search-icon {
+    @apply absolute left-2 text-notion-muted dark:text-[#5f6368] pointer-events-none;
+  }
+
+  .sidebar-search {
+    @apply w-full pl-6 pr-2 py-1 text-xs rounded-md outline-none
+           bg-notion-hover dark:bg-[#2d2f31]
+           border border-transparent focus:border-notion-accent dark:focus:border-[#8ab4f8]
+           text-notion-text dark:text-[#e8eaed]
+           placeholder-notion-muted dark:placeholder-[#5f6368]
+           transition-colors;
+  }
+
+  .sidebar-empty {
+    @apply flex flex-col items-center justify-center pt-10 pb-6 px-4
+           text-notion-muted dark:text-[#5f6368];
+  }
+
   /* ─── Toolbar (legacy helpers) ─── */
   .toolbar {
     @apply flex items-center gap-0.5 flex-wrap;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -156,6 +156,51 @@
            text-notion-muted font-bold text-sm flex-shrink-0 font-mono;
   }
 
+  /* ─── Sidebar ─── */
+  .sidebar {
+    @apply w-60 flex-shrink-0 flex flex-col h-full
+           bg-notion-sidebar dark:bg-[#181818]
+           border-r border-notion-border dark:border-[#3c4043];
+  }
+
+  .sidebar-header {
+    @apply flex items-center justify-between px-4 py-3
+           border-b border-notion-border dark:border-[#3c4043] flex-shrink-0;
+  }
+
+  .sidebar-new-btn {
+    @apply w-6 h-6 flex items-center justify-center rounded
+           text-notion-muted dark:text-[#9aa0a6]
+           hover:bg-notion-hover dark:hover:bg-[#2d2f31]
+           hover:text-notion-text dark:hover:text-[#e8eaed]
+           transition-colors;
+  }
+
+  .sidebar-item {
+    @apply flex items-center gap-2 px-2 py-1.5 rounded-md cursor-pointer text-sm
+           transition-colors text-notion-muted dark:text-[#9aa0a6]
+           hover:bg-notion-hover dark:hover:bg-[#2d2f31]
+           hover:text-notion-text dark:hover:text-[#e8eaed];
+  }
+
+  .sidebar-item.active {
+    @apply bg-notion-hover dark:bg-[#2d2f31]
+           text-notion-text dark:text-[#e8eaed] font-medium;
+  }
+
+  .sidebar-rename-input {
+    @apply flex-1 min-w-0 bg-white dark:bg-[#2d2f31] rounded px-1 text-sm
+           text-notion-text dark:text-[#e8eaed] outline-none
+           border border-notion-accent dark:border-[#8ab4f8];
+  }
+
+  .sidebar-delete-btn {
+    @apply opacity-0 group-hover:opacity-100 flex-shrink-0
+           w-5 h-5 flex items-center justify-center rounded
+           text-notion-muted hover:text-red-500 dark:hover:text-red-400
+           transition-all;
+  }
+
   /* ─── Toolbar (legacy helpers) ─── */
   .toolbar {
     @apply flex items-center gap-0.5 flex-wrap;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -156,6 +156,31 @@
            text-notion-muted font-bold text-sm flex-shrink-0 font-mono;
   }
 
+  /* ─── Drag-to-reorder ─── */
+  .drag-handle {
+    position: absolute;
+    top: 0;
+    left: 0;
+    will-change: transform;
+    opacity: 0;
+    @apply flex items-center justify-center w-5 h-5 rounded
+           cursor-grab active:cursor-grabbing
+           text-notion-muted dark:text-[#9aa0a6]
+           hover:bg-notion-hover dark:hover:bg-[#2d2f31]
+           transition-colors;
+  }
+
+  .drag-target-line {
+    position: absolute;
+    top: 0;
+    left: 0;
+    will-change: transform;
+    height: 4px;
+    opacity: 0;
+    pointer-events: none;
+    @apply bg-notion-accent rounded-full;
+  }
+
   /* ─── Sidebar ─── */
   .sidebar {
     @apply w-60 flex-shrink-0 flex flex-col h-full

--- a/apps/web/src/types/editor.ts
+++ b/apps/web/src/types/editor.ts
@@ -21,6 +21,12 @@ export interface AutoSaveData {
   content: string;
 }
 
+export interface DocMeta {
+  id: string;
+  title: string;
+  updatedAt: number;
+}
+
 export interface EditorToolbarProps {
   editor: LexicalEditor;
   onExportPDF: () => void;


### PR DESCRIPTION
## Documents workspace

- Document store — useDocumentStore hook manages a list of documents in localStorage, with create, rename, remove, activate, and touch operations. All documents are stored individually under hawkdoc-doc-{id} keys; metadata (id, title, last modified) is tracked separately under hawkdoc-docs.
- Sidebar — Left-hand sidebar shows all documents sorted by last modified. Active document is highlighted. Double-click a document title to rename it inline. Hover to reveal the delete button. A + button at the top creates a new document.
- Multi-document auto-save — useAutoSave now takes a docId and saves each document to its own storage key. loadDocContent(docId) replaces the old single-doc loadAutoSave.
- Document switching — Editor receives key={activeId} so it fully re-mounts when switching documents, ensuring clean editor state with no bleed between docs.
- Migration — Existing users' data in the old hawkdoc-autosave key is automatically migrated to the new per-document format on first load.
- Title sync — Editing the document title in the editor updates the sidebar instantly via touch(), keeping name and last-modified timestamp in sync.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Docs / chore

## How to test
<!-- Steps to verify this works -->

## Screenshots
<!-- If the UI changed, add before/after screenshots -->

## Checklist
- [ ] Tests pass
- [ ] No TypeScript errors (`npm run typecheck`)
- [ ] No lint warnings (`npm run lint`)
- [ ] Docs updated if needed
- [ ] Targets the `dev` branch (not `main`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Documents sidebar to create, switch, rename, and delete documents.
  * Added draggable block controls inside the editor paper area.
  * Enabled multi-document editing with the active document remembered between sessions.
* **Bug Fixes**
  * Improved saving to store editor content per document (instead of a single global save).
  * Migrated existing single-document data into the new multi-document setup, preserving your title and content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->