### PR TITLE
[Enhancement] - Refactor type imports and restructure document handling with React Query integration

### DIFF
--- a/apps/api/src/hocuspocus.ts
+++ b/apps/api/src/hocuspocus.ts
@@ -4,10 +4,7 @@ import { env } from './env.js';
 import query from './db.js';
 import { redis, docBufferKey } from './redis.js';
 import * as Y from 'yjs';
-
-interface HocuspocusContext {
-  userId: string;
-}
+import type { HocuspocusContext } from './interfaces/index.js';
 
 export const hocuspocusServer = Server.configure({
   port: env.HOCUSPOCUS_PORT,

--- a/apps/api/src/interfaces/index.ts
+++ b/apps/api/src/interfaces/index.ts
@@ -8,3 +8,7 @@ export interface AuthPayload {
 export interface AuthenticatedRequest extends Request {
   auth: AuthPayload;
 }
+
+export interface HocuspocusContext {
+  userId: string;
+}

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,7 +1,7 @@
 import type { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
 import { env } from '../env.js';
-import type { AuthPayload, AuthenticatedRequest } from '../types/auth.js';
+import type { AuthPayload, AuthenticatedRequest } from '../interfaces/index.js';
 
 export type { AuthPayload, AuthenticatedRequest };
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
     "@lexical/table": "^0.17.1",
     "@lexical/utils": "^0.17.1",
     "@react-pdf/renderer": "^3.4.4",
+    "@tanstack/react-query": "^5.101.2",
     "@tanstack/react-virtual": "^3.8.1",
     "lexical": "^0.17.1",
     "lucide-react": "^0.576.0",

--- a/apps/web/src/components/Editor.tsx
+++ b/apps/web/src/components/Editor.tsx
@@ -33,7 +33,7 @@ import { FindReplacePlugin } from './FindReplacePlugin';
 import { DraggableBlockPlugin } from './DraggableBlockPlugin';
 import { useAutoSave, loadDocContent } from '../hooks/useAutoSave';
 import { TEMPLATE_VAR_REGEX, EDITOR_THEME, EDITOR_NODES } from '../constants/editor';
-import type { SlashMenuState } from '../types/editor';
+import type { SlashMenuState } from '../interfaces';
 
 // ─── Slash + template-variable detection plugin ───────────────────────────────
 

--- a/apps/web/src/components/EditorToolbar.tsx
+++ b/apps/web/src/components/EditorToolbar.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
 import { InputDialog } from './InputDialog';
 import {
   $getSelection,
@@ -26,8 +27,9 @@ import {
 import { $getNearestNodeOfType, $insertNodeToNearestRoot } from '@lexical/utils';
 import { $convertToMarkdownString, TRANSFORMERS } from '@lexical/markdown';
 import { $createImageNode } from '../nodes/ImageNode';
+import { uploadImage } from '../lib/documentApi';
 import { BLOCK_TYPES, FONT_FAMILIES, FONT_SIZES } from '../constants/editor';
-import type { BlockType, EditorToolbarProps } from '../types/editor';
+import type { BlockType, EditorToolbarProps } from '../interfaces';
 import {
   Bold,
   Italic,
@@ -313,27 +315,22 @@ export function EditorToolbar({ editor, onExportPDF, isSaving, title, onToggleFo
     setExportOpen(false);
   }, [getMarkdownString]);
 
-  const handleImageUpload = useCallback(
-    async (file: File) => {
-      const apiUrl =
-        (import.meta.env.VITE_API_URL as string | undefined) ?? 'http://localhost:3001';
-      const formData = new FormData();
-      formData.append('image', file);
-      try {
-        const res = await fetch(`${apiUrl}/api/uploads`, { method: 'POST', body: formData });
-        if (!res.ok) {
-          const body = await res.text();
-          throw new Error(`Upload failed (${res.status}): ${body}`);
-        }
-        const { url } = (await res.json()) as { url: string };
-        editor.update(() => {
-          $insertNodeToNearestRoot($createImageNode(`${apiUrl}${url}`, file.name));
-        });
-      } catch (err) {
-        console.error('Image upload failed:', err);
-      }
+  const imageUploadMutation = useMutation({
+    mutationFn: uploadImage,
+    onSuccess: ({ url }, file) => {
+      const apiUrl = (import.meta.env.VITE_API_URL as string | undefined) ?? 'http://localhost:3001';
+      editor.update(() => {
+        $insertNodeToNearestRoot($createImageNode(`${apiUrl}${url}`, file.name));
+      });
     },
-    [editor],
+    onError: (err) => {
+      console.error('Image upload failed:', err);
+    },
+  });
+
+  const handleImageUpload = useCallback(
+    (file: File) => { imageUploadMutation.mutate(file); },
+    [imageUploadMutation],
   );
 
   const currentLabel = BLOCK_TYPES.find((b) => b.type === blockType)?.label ?? 'Paragraph';

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { FilePlus, FileText, Search, Trash2 } from 'lucide-react';
-import type { DocMeta } from '../types/editor';
+import type { DocMeta } from '../interfaces';
 
 interface SidebarProps {
   docs: DocMeta[];

--- a/apps/web/src/components/SlashCommandMenu.tsx
+++ b/apps/web/src/components/SlashCommandMenu.tsx
@@ -26,7 +26,7 @@ import { $createHorizontalRuleNode } from '@lexical/react/LexicalHorizontalRuleN
 import { $createTemplateVariableNode } from '../nodes/TemplateVariableNode';
 import { INSERT_TABLE_COMMAND } from '@lexical/table';
 import { $createPageBreakNode } from '../nodes/PageBreakNode';
-import type { SlashCommand } from '../types/editor';
+import type { SlashCommand } from '../interfaces';
 
 const COMMANDS: SlashCommand[] = [
   {

--- a/apps/web/src/constants/editor.ts
+++ b/apps/web/src/constants/editor.ts
@@ -7,7 +7,7 @@ import { TableNode, TableRowNode, TableCellNode } from '@lexical/table';
 import { TemplateVariableNode } from '../nodes/TemplateVariableNode';
 import { ImageNode } from '../nodes/ImageNode';
 import { PageBreakNode } from '../nodes/PageBreakNode';
-import type { BlockType } from '../types/editor';
+import type { BlockType } from '../interfaces';
 
 export const TEMPLATE_VAR_REGEX = /\{\{([a-zA-Z_][a-zA-Z0-9_]*)\}\}/;
 

--- a/apps/web/src/context/DocumentContext.ts
+++ b/apps/web/src/context/DocumentContext.ts
@@ -1,9 +1,5 @@
 import { createContext, useContext } from 'react';
-
-interface DocumentContextValue {
-  header: string;
-  footer: string;
-}
+import type { DocumentContextValue } from '../interfaces';
 
 export const DocumentContext = createContext<DocumentContextValue | null>(null);
 

--- a/apps/web/src/hooks/useAutoSave.ts
+++ b/apps/web/src/hooks/useAutoSave.ts
@@ -1,7 +1,9 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
+import { useMutation } from '@tanstack/react-query';
 import type { EditorState } from 'lexical';
 import { DOC_KEY_PREFIX, DEBOUNCE_MS } from '../constants/autosave';
-import type { AutoSaveData } from '../types/editor';
+import { saveDocContent } from '../lib/documentApi';
+import type { AutoSaveData } from '../interfaces';
 
 export function loadDocContent(docId: string): AutoSaveData | null {
   try {
@@ -23,24 +25,24 @@ export function useAutoSave(
   title: string,
   docId: string,
 ): boolean {
-  const [isSaving, setIsSaving] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const saveMutation = useMutation({
+    mutationFn: (data: AutoSaveData) => saveDocContent(docId, data),
+  });
 
   useEffect(() => {
     if (!editorState) return;
     if (timerRef.current) clearTimeout(timerRef.current);
 
     timerRef.current = setTimeout(() => {
-      setIsSaving(true);
-      try {
-        const data: AutoSaveData = { title, content: JSON.stringify(editorState.toJSON()) };
-        localStorage.setItem(`${DOC_KEY_PREFIX}${docId}`, JSON.stringify(data));
-      } catch { /* ignore storage errors */ }
-      setTimeout(() => setIsSaving(false), 600);
+      const data: AutoSaveData = { title, content: JSON.stringify(editorState.toJSON()) };
+      saveMutation.mutate(data);
     }, DEBOUNCE_MS);
 
     return () => { if (timerRef.current) clearTimeout(timerRef.current); };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editorState, title, docId]);
 
-  return isSaving;
+  return saveMutation.isPending;
 }

--- a/apps/web/src/hooks/useAutoSave.ts
+++ b/apps/web/src/hooks/useAutoSave.ts
@@ -26,6 +26,7 @@ export function useAutoSave(
   docId: string,
 ): boolean {
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingDataRef = useRef<AutoSaveData | null>(null);
 
   const saveMutation = useMutation({
     mutationFn: (data: AutoSaveData) => saveDocContent(docId, data),
@@ -35,12 +36,26 @@ export function useAutoSave(
     if (!editorState) return;
     if (timerRef.current) clearTimeout(timerRef.current);
 
+    const data: AutoSaveData = { title, content: JSON.stringify(editorState.toJSON()) };
+    pendingDataRef.current = data;
+
     timerRef.current = setTimeout(() => {
-      const data: AutoSaveData = { title, content: JSON.stringify(editorState.toJSON()) };
       saveMutation.mutate(data);
+      timerRef.current = null;
+      pendingDataRef.current = null;
     }, DEBOUNCE_MS);
 
-    return () => { if (timerRef.current) clearTimeout(timerRef.current); };
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+      // Flush pending save immediately on unmount/doc switch
+      if (pendingDataRef.current) {
+        saveMutation.mutate(pendingDataRef.current);
+        pendingDataRef.current = null;
+      }
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editorState, title, docId]);
 

--- a/apps/web/src/hooks/useDocumentStore.ts
+++ b/apps/web/src/hooks/useDocumentStore.ts
@@ -53,11 +53,11 @@ export function useDocumentStore() {
     onMutate: (removedId) => {
       const prev = queryClient.getQueryData<DocMeta[]>(DOCS_KEY) ?? [];
       const next = prev.filter((d) => d.id !== removedId);
+      queryClient.setQueryData<DocMeta[]>(DOCS_KEY, next);
       if (next.length === 0) {
         createMutation.mutate();
-      } else {
-        queryClient.setQueryData<DocMeta[]>(DOCS_KEY, next);
-        if (removedId === resolvedActiveId) switchTo(next[0].id);
+      } else if (removedId === resolvedActiveId) {
+        switchTo(next[0].id);
       }
     },
   });

--- a/apps/web/src/hooks/useDocumentStore.ts
+++ b/apps/web/src/hooks/useDocumentStore.ts
@@ -1,81 +1,83 @@
-import { useState } from 'react';
-import { DOCS_LIST_KEY, DOC_KEY_PREFIX, ACTIVE_DOC_KEY, STORAGE_KEY } from '../constants/autosave';
-import type { DocMeta } from '../types/editor';
+import { useCallback, useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { ACTIVE_DOC_KEY } from '../constants/autosave';
+import {
+  fetchDocuments,
+  createDocument,
+  renameDocument,
+  removeDocument,
+} from '../lib/documentApi';
+import type { DocMeta } from '../interfaces';
 
-function genId(): string {
-  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
-}
+const DOCS_KEY = ['documents'] as const;
 
-function saveDocs(docs: DocMeta[]): void {
-  localStorage.setItem(DOCS_LIST_KEY, JSON.stringify(docs));
-}
-
-function initialDocs(): DocMeta[] {
-  try {
-    const raw = localStorage.getItem(DOCS_LIST_KEY);
-    if (raw) return JSON.parse(raw) as DocMeta[];
-  } catch { /* ignore */ }
-
-  // Migrate from old single-doc format
-  const id = genId();
-  const old = localStorage.getItem(STORAGE_KEY);
-  let title = 'Untitled';
-  try { if (old) title = (JSON.parse(old) as { title?: string }).title ?? 'Untitled'; } catch { /* ignore */ }
-  if (old) localStorage.setItem(`${DOC_KEY_PREFIX}${id}`, old);
-
-  const docs: DocMeta[] = [{ id, title, updatedAt: Date.now() }];
-  saveDocs(docs);
-  return docs;
-}
-
-function initialActiveId(docs: DocMeta[]): string {
+function getStoredActiveId(docs: DocMeta[]): string {
   const stored = localStorage.getItem(ACTIVE_DOC_KEY);
   return stored && docs.some((d) => d.id === stored) ? stored : (docs[0]?.id ?? '');
 }
 
 export function useDocumentStore() {
-  const [docs, setDocs] = useState<DocMeta[]>(initialDocs);
-  const [activeId, setActiveId] = useState<string>(() => initialActiveId(initialDocs()));
+  const queryClient = useQueryClient();
+  const { data: docs = [] } = useQuery({ queryKey: DOCS_KEY, queryFn: fetchDocuments });
 
-  const update = (next: DocMeta[]) => {
-    setDocs(next);
-    saveDocs(next);
-  };
+  const [activeId, setActiveId] = useState<string>(() => getStoredActiveId(docs));
 
-  const switchTo = (id: string) => {
+  const resolvedActiveId = docs.some((d) => d.id === activeId)
+    ? activeId
+    : (docs[0]?.id ?? '');
+
+  const switchTo = useCallback((id: string) => {
     setActiveId(id);
     localStorage.setItem(ACTIVE_DOC_KEY, id);
-  };
+  }, []);
 
-  const create = (): string => {
-    const id = genId();
-    const next = [{ id, title: 'Untitled', updatedAt: Date.now() }, ...docs];
-    update(next);
-    switchTo(id);
-    return id;
-  };
+  const createMutation = useMutation({
+    mutationFn: createDocument,
+    onSuccess: (newDoc) => {
+      queryClient.setQueryData<DocMeta[]>(DOCS_KEY, (old = []) => [newDoc, ...old]);
+      switchTo(newDoc.id);
+    },
+  });
 
-  const rename = (id: string, title: string) => {
-    update(docs.map((d) => (d.id === id ? { ...d, title, updatedAt: Date.now() } : d)));
-  };
+  const renameMutation = useMutation({
+    mutationFn: ({ id, title }: { id: string; title: string }) => renameDocument(id, title),
+    onMutate: ({ id, title }) => {
+      queryClient.setQueryData<DocMeta[]>(DOCS_KEY, (old = []) =>
+        old.map((d) => (d.id === id ? { ...d, title, updatedAt: Date.now() } : d)),
+      );
+    },
+  });
 
-  const remove = (id: string) => {
-    const next = docs.filter((d) => d.id !== id);
-    localStorage.removeItem(`${DOC_KEY_PREFIX}${id}`);
-    if (next.length === 0) {
-      const newId = genId();
-      const fresh: DocMeta[] = [{ id: newId, title: 'Untitled', updatedAt: Date.now() }];
-      update(fresh);
-      switchTo(newId);
-    } else {
-      update(next);
-      if (id === activeId) switchTo(next[0].id);
-    }
-  };
+  const removeMutation = useMutation({
+    mutationFn: removeDocument,
+    onMutate: (removedId) => {
+      const prev = queryClient.getQueryData<DocMeta[]>(DOCS_KEY) ?? [];
+      const next = prev.filter((d) => d.id !== removedId);
+      if (next.length === 0) {
+        createMutation.mutate();
+      } else {
+        queryClient.setQueryData<DocMeta[]>(DOCS_KEY, next);
+        if (removedId === resolvedActiveId) switchTo(next[0].id);
+      }
+    },
+  });
 
-  const touch = (id: string, title: string) => {
-    update(docs.map((d) => (d.id === id ? { ...d, title, updatedAt: Date.now() } : d)));
-  };
+  const touchMutation = useMutation({
+    mutationFn: ({ id, title }: { id: string; title: string }) => renameDocument(id, title),
+    onMutate: ({ id, title }) => {
+      queryClient.setQueryData<DocMeta[]>(DOCS_KEY, (old = []) =>
+        old.map((d) => (d.id === id ? { ...d, title, updatedAt: Date.now() } : d)),
+      );
+    },
+  });
 
-  return { docs, activeId, create, rename, remove, activate: switchTo, touch };
+  return {
+    docs,
+    activeId: resolvedActiveId,
+    create: () => { createMutation.mutate(); },
+    rename: (id: string, title: string) => renameMutation.mutate({ id, title }),
+    remove: (id: string) => removeMutation.mutate(id),
+    activate: switchTo,
+    touch: (id: string, title: string) => touchMutation.mutate({ id, title }),
+  };
 }

--- a/apps/web/src/interfaces/index.ts
+++ b/apps/web/src/interfaces/index.ts
@@ -34,3 +34,8 @@ export interface EditorToolbarProps {
   title: string;
   onToggleFocusMode: () => void;
 }
+
+export interface DocumentContextValue {
+  header: string;
+  footer: string;
+}

--- a/apps/web/src/lib/documentApi.ts
+++ b/apps/web/src/lib/documentApi.ts
@@ -37,9 +37,11 @@ export async function createDocument(): Promise<DocMeta> {
 
 export async function renameDocument(id: string, title: string): Promise<DocMeta> {
   const docs = await fetchDocuments();
-  const updated = docs.map((d) => (d.id === id ? { ...d, title, updatedAt: Date.now() } : d));
-  saveDocs(updated);
-  return updated.find((d) => d.id === id)!;
+  const doc = docs.find((d) => d.id === id);
+  if (!doc) throw new Error(`Document not found: ${id}`);
+  const renamed = { ...doc, title, updatedAt: Date.now() };
+  saveDocs(docs.map((d) => (d.id === id ? renamed : d)));
+  return renamed;
 }
 
 export async function removeDocument(id: string): Promise<void> {

--- a/apps/web/src/lib/documentApi.ts
+++ b/apps/web/src/lib/documentApi.ts
@@ -1,0 +1,66 @@
+import { DOCS_LIST_KEY, DOC_KEY_PREFIX, STORAGE_KEY } from '../constants/autosave';
+import type { AutoSaveData, DocMeta } from '../interfaces';
+
+function genId(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+}
+
+function saveDocs(docs: DocMeta[]): void {
+  localStorage.setItem(DOCS_LIST_KEY, JSON.stringify(docs));
+}
+
+export async function fetchDocuments(): Promise<DocMeta[]> {
+  const raw = localStorage.getItem(DOCS_LIST_KEY);
+  if (raw) return JSON.parse(raw) as DocMeta[];
+
+  // Migrate from old single-doc format
+  const id = genId();
+  const old = localStorage.getItem(STORAGE_KEY);
+  let title = 'Untitled';
+  try {
+    if (old) title = (JSON.parse(old) as { title?: string }).title ?? 'Untitled';
+  } catch { /* ignore */ }
+  if (old) localStorage.setItem(`${DOC_KEY_PREFIX}${id}`, old);
+
+  const docs: DocMeta[] = [{ id, title, updatedAt: Date.now() }];
+  saveDocs(docs);
+  return docs;
+}
+
+export async function createDocument(): Promise<DocMeta> {
+  const id = genId();
+  const doc: DocMeta = { id, title: 'Untitled', updatedAt: Date.now() };
+  const docs = await fetchDocuments();
+  saveDocs([doc, ...docs]);
+  return doc;
+}
+
+export async function renameDocument(id: string, title: string): Promise<DocMeta> {
+  const docs = await fetchDocuments();
+  const updated = docs.map((d) => (d.id === id ? { ...d, title, updatedAt: Date.now() } : d));
+  saveDocs(updated);
+  return updated.find((d) => d.id === id)!;
+}
+
+export async function removeDocument(id: string): Promise<void> {
+  const docs = await fetchDocuments();
+  const next = docs.filter((d) => d.id !== id);
+  localStorage.removeItem(`${DOC_KEY_PREFIX}${id}`);
+  saveDocs(next);
+}
+
+export async function saveDocContent(docId: string, data: AutoSaveData): Promise<void> {
+  localStorage.setItem(`${DOC_KEY_PREFIX}${docId}`, JSON.stringify(data));
+}
+
+export async function uploadImage(file: File): Promise<{ url: string }> {
+  const apiUrl = (import.meta.env.VITE_API_URL as string | undefined) ?? 'http://localhost:3001';
+  const formData = new FormData();
+  formData.append('image', file);
+  const res = await fetch(`${apiUrl}/api/uploads`, { method: 'POST', body: formData });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Upload failed (${res.status}): ${body}`);
+  }
+  return (await res.json()) as { url: string };
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,13 +1,25 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import './index.css';
 import App from './App';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: Infinity,
+      retry: false,
+    },
+  },
+});
 
 const root = document.getElementById('root');
 if (!root) throw new Error('Root element not found');
 
 createRoot(root).render(
   <StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </StrictMode>,
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
         "@lexical/table": "^0.17.1",
         "@lexical/utils": "^0.17.1",
         "@react-pdf/renderer": "^3.4.4",
+        "@tanstack/react-query": "^5.101.2",
         "@tanstack/react-virtual": "^3.8.1",
         "lexical": "^0.17.1",
         "lucide-react": "^0.576.0",
@@ -1151,6 +1152,32 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.2.tgz",
+      "integrity": "sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.101.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.2.tgz",
+      "integrity": "sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.101.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tanstack/react-virtual": {


### PR DESCRIPTION
## Refactor frontend data layer with TanStack React Query and reorganize type definitions  
   
  - Replaced raw useEffect + useState data fetching with useQuery and
  useMutation for document CRUD, auto-save, and image upload                
  - Created documentApi.ts persistence adapter for easy future API migration
  - Moved all types/interfaces into dedicated interfaces/ folders for       
  frontend and backend
  - Removed useDebouncedFetch.ts (superseded by TanStack Query)

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Docs / chore

## How to test
<!-- Steps to verify this works -->

## Screenshots
<!-- If the UI changed, add before/after screenshots -->

## Checklist
- [ ] Tests pass
- [ ] No TypeScript errors (`npm run typecheck`)
- [ ] No lint warnings (`npm run lint`)
- [ ] Docs updated if needed
- [ ] Targets the `dev` branch (not `main`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for creating, renaming, switching, and deleting documents.
  - Added automatic document content saving.
  - Added image uploads directly from the editor toolbar.
  - Added migration support for existing single-document data.

- **Improvements**
  - Document updates now appear more smoothly and reliably.
  - Active-document selection remains valid after documents are removed.
  - Added a default “Untitled” document when no documents exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->